### PR TITLE
Show a helpful popup for malformed json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [push]
 
 jobs:
   tests:

--- a/src/main.c
+++ b/src/main.c
@@ -664,6 +664,9 @@ static LSAppWindow* ls_app_window_new(LSApp* app)
 
 static void ls_app_window_open(LSAppWindow* win, const char* file)
 {
+	char* error_msg = NULL;
+	GtkWidget* error_popup;
+	
     if (win->timer) {
         ls_app_window_clear_game(win);
         ls_timer_release(win->timer);
@@ -673,8 +676,22 @@ static void ls_app_window_open(LSAppWindow* win, const char* file)
         ls_game_release(win->game);
         win->game = 0;
     }
-    if (ls_game_create(&win->game, file)) {
+    if (ls_game_create(&win->game, file, &error_msg)) {
         win->game = 0;
+        if (error_msg) {
+			error_popup = gtk_message_dialog_new(
+				GTK_WINDOW(win),
+				GTK_DIALOG_DESTROY_WITH_PARENT,
+				GTK_MESSAGE_INFO,
+				GTK_BUTTONS_OK,
+				"JSON parse error: %s",
+				error_msg
+			);
+			gtk_dialog_run(GTK_DIALOG(error_popup));
+			
+        	free(error_msg);
+        	gtk_widget_destroy(error_popup);
+        }
     } else if (ls_timer_create(&win->timer, win->game)) {
         win->timer = 0;
     } else {

--- a/src/main.c
+++ b/src/main.c
@@ -664,9 +664,9 @@ static LSAppWindow* ls_app_window_new(LSApp* app)
 
 static void ls_app_window_open(LSAppWindow* win, const char* file)
 {
-	char* error_msg = NULL;
-	GtkWidget* error_popup;
-	
+    char* error_msg = NULL;
+    GtkWidget* error_popup;
+
     if (win->timer) {
         ls_app_window_clear_game(win);
         ls_timer_release(win->timer);
@@ -679,18 +679,18 @@ static void ls_app_window_open(LSAppWindow* win, const char* file)
     if (ls_game_create(&win->game, file, &error_msg)) {
         win->game = 0;
         if (error_msg) {
-			error_popup = gtk_message_dialog_new(
-				GTK_WINDOW(win),
-				GTK_DIALOG_DESTROY_WITH_PARENT,
-				GTK_MESSAGE_INFO,
-				GTK_BUTTONS_OK,
-				"JSON parse error: %s",
-				error_msg
-			);
-			gtk_dialog_run(GTK_DIALOG(error_popup));
-			
-        	free(error_msg);
-        	gtk_widget_destroy(error_popup);
+            error_popup = gtk_message_dialog_new(
+                GTK_WINDOW(win),
+                GTK_DIALOG_DESTROY_WITH_PARENT,
+                GTK_MESSAGE_INFO,
+                GTK_BUTTONS_OK,
+                "JSON parse error: %s\n%s",
+                error_msg,
+                file);
+            gtk_dialog_run(GTK_DIALOG(error_popup));
+
+            free(error_msg);
+            gtk_widget_destroy(error_popup);
         }
     } else if (ls_timer_create(&win->timer, win->game)) {
         win->timer = 0;

--- a/src/timer.c
+++ b/src/timer.c
@@ -178,7 +178,9 @@ int ls_game_create(ls_game** game_ptr, const char* path, char** error_msg)
     json = json_load_file(game->path, 0, &json_error);
     if (!json) {
         error = 1;
-        *error_msg = strdup(json_error.text);
+        size_t msg_len = snprintf(NULL, 0, "%s (%d:%d)", json_error.text, json_error.line, json_error.column);
+        *error_msg = calloc(msg_len, sizeof(char));
+        sprintf(*error_msg, "%s (%d:%d)", json_error.text, json_error.line, json_error.column);
         goto game_create_done;
     }
     // copy title

--- a/src/timer.c
+++ b/src/timer.c
@@ -179,7 +179,7 @@ int ls_game_create(ls_game** game_ptr, const char* path, char** error_msg)
     if (!json) {
         error = 1;
         size_t msg_len = snprintf(NULL, 0, "%s (%d:%d)", json_error.text, json_error.line, json_error.column);
-        *error_msg = calloc(msg_len, sizeof(char));
+        *error_msg = calloc(msg_len + 1, sizeof(char));
         sprintf(*error_msg, "%s (%d:%d)", json_error.text, json_error.line, json_error.column);
         goto game_create_done;
     }

--- a/src/timer.c
+++ b/src/timer.c
@@ -154,7 +154,7 @@ void ls_game_release(ls_game* game)
     }
 }
 
-int ls_game_create(ls_game** game_ptr, const char* path)
+int ls_game_create(ls_game** game_ptr, const char* path, char** error_msg)
 {
     int error = 0;
     ls_game* game;
@@ -178,6 +178,7 @@ int ls_game_create(ls_game** game_ptr, const char* path)
     json = json_load_file(game->path, 0, &json_error);
     if (!json) {
         error = 1;
+        *error_msg = strdup(json_error.text);
         goto game_create_done;
     }
     // copy title

--- a/src/timer.h
+++ b/src/timer.h
@@ -59,7 +59,7 @@ void ls_split_string(char* string, long long time);
 
 void ls_delta_string(char* string, long long time);
 
-int ls_game_create(ls_game** game_ptr, const char* path);
+int ls_game_create(ls_game** game_ptr, const char* path, char** error_msg);
 
 void ls_game_update_splits(ls_game* game, const ls_timer* timer);
 


### PR DESCRIPTION
Short little pull request (and admittedly my first to a public repo so hopefully I've done alright!)

![image](https://github.com/wins1ey/LibreSplit/assets/6373518/24baef42-a9c2-4f95-879e-a4b63071b8c1)

I found this repo awhile back and really looked forward to trying it out once I had the rest of my setup together for speedrunning again. Finally with the chance to poke at it today, I found myself stumped for quite some time trying to make a splits file. Little did I know that proper JSON could have extraneous commas!

Alas, I only figured this out after digging through the source and a bit of "print statement debugging." I figured while I was in there, might as well extend that out to a proper GUI popup instead.

If you'd be interested to merge such a thing but have any reservations, please let me know and I'd be happy to try and resolve them!