### PR TITLE
Update main.css to use CSS format for font

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -2,7 +2,7 @@
 	background: #222;
 	padding: 0;
 	margin: 0;
-	font: Roboto, Droid Sans, Open Sans, Ubuntu, Cantarell, Arial, FreeSans, Liberation Sans;
+	font-family: Roboto, Droid Sans, Open Sans, Ubuntu, Cantarell, Arial, FreeSans, Liberation Sans;
 }
 .header {
 	background: linear-gradient(#555,#222);


### PR DESCRIPTION
This fixes the `Gtk-WARNING` that appears when running LibreSplit:

```
(libresplit:4175): Gtk-WARNING **: 11:25:54.716: Theme parsing error: <data>:5:7: not a number

(libresplit:4175): Gtk-WARNING **: 11:25:54.716: Theme parsing error: <data>:5:89: Using Pango syntax for the font: style property is deprecated; please use CSS syntax
```