### PR TITLE
Add website URL to title text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="libresplit.svg" width=43 align=top> [LibreSplit](https://libresplit.loomeh.tech)
+# <img src="libresplit.svg" width=43 align=top> [LibreSplit](https://libresplit.loomeh.is-a.dev)
 
 LibreSplit brings auto splitting functionality to [urn](https://github.com/3snowp7im/urn) with Lua-based auto splitters that are easy to port from asl.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="libresplit.svg" width=43 align=top> LibreSplit
+# <img src="libresplit.svg" width=43 align=top> [LibreSplit](https://libresplit.loomeh.tech)
 
 LibreSplit brings auto splitting functionality to [urn](https://github.com/3snowp7im/urn) with Lua-based auto splitters that are easy to port from asl.
 


### PR DESCRIPTION
Created a website for LibreSplit. It's loosely themed after the LiveSplit website.

[URL](https://libresplit.loomeh.tech)

The website contains a LibreSplit AppImage download, installation/compilation instructions and a FAQ.

The website's source code has its own [repo](https://github.com/Loomeh/libresplit-website) on my profile.

The website is currently being hosted on a subdomain on my personal domain. I saw that the libresplit.org domain was taken and it currently redirects to this GitHub page. I don't know what the plans are relating to that.