### PR TITLE
Add finished counter to splits

### DIFF
--- a/src/component/title.c
+++ b/src/component/title.c
@@ -5,6 +5,7 @@ typedef struct _LSTitle {
     GtkWidget* header;
     GtkWidget* title;
     GtkWidget* attempt_count;
+    GtkWidget* finished_count;
 } LSTitle;
 extern LSComponentOps ls_title_operations; // defined at the end of the file
 
@@ -35,6 +36,13 @@ LSComponent* ls_component_title_new()
     gtk_widget_set_valign(self->attempt_count, GTK_ALIGN_START);
     gtk_container_add(GTK_CONTAINER(self->header), self->attempt_count);
     gtk_widget_show(self->attempt_count);
+    
+    self->finished_count = gtk_label_new(NULL);
+    add_class(self->finished_count, "finished_count");
+    gtk_widget_set_margin_start(self->finished_count, 8);
+    gtk_widget_set_valign(self->finished_count, GTK_ALIGN_START);
+    gtk_container_add(GTK_CONTAINER(self->header), self->finished_count);
+    gtk_widget_show(self->finished_count);
 
     return (LSComponent*)self;
 }
@@ -53,13 +61,16 @@ static void title_resize(LSComponent* self_, int win_width, int win_height)
 {
     GdkRectangle rect;
     int attempt_count_width;
+    int finished_count_width;
     int title_width;
     LSTitle* self = (LSTitle*)self_;
 
     gtk_widget_hide(self->title);
     gtk_widget_get_allocation(self->attempt_count, &rect);
     attempt_count_width = rect.width;
-    title_width = win_width - attempt_count_width;
+    gtk_widget_get_allocation(self->finished_count, &rect);
+    finished_count_width = rect.width;
+    title_width = win_width - (attempt_count_width + finished_count_width);
     rect.width = title_width;
     gtk_widget_show(self->title);
     gtk_widget_set_allocation(self->title, &rect);
@@ -77,10 +88,16 @@ static void title_show_game(LSComponent* self_, ls_game* game,
 
 static void title_draw(LSComponent* self_, ls_game* game, ls_timer* timer)
 {
-    char str[64];
+    char attempt_str[64];
+    char finished_str[64];
+    char combi_str[64];
     LSTitle* self = (LSTitle*)self_;
-    sprintf(str, "#%d", game->attempt_count);
-    gtk_label_set_text(GTK_LABEL(self->attempt_count), str);
+    sprintf(attempt_str, "%d", game->attempt_count);
+    sprintf(finished_str, "#%d", game->finished_count);
+    strcpy(combi_str, finished_str);
+    strcat(combi_str, "/");
+    strcat(combi_str, attempt_str);
+    gtk_label_set_text(GTK_LABEL(self->attempt_count), combi_str);
 }
 
 LSComponentOps ls_title_operations = {

--- a/src/component/title.c
+++ b/src/component/title.c
@@ -36,7 +36,7 @@ LSComponent* ls_component_title_new()
     gtk_widget_set_valign(self->attempt_count, GTK_ALIGN_START);
     gtk_container_add(GTK_CONTAINER(self->header), self->attempt_count);
     gtk_widget_show(self->attempt_count);
-    
+
     self->finished_count = gtk_label_new(NULL);
     add_class(self->finished_count, "finished_count");
     gtk_widget_set_margin_start(self->finished_count, 8);

--- a/src/timer.c
+++ b/src/timer.c
@@ -215,7 +215,7 @@ int ls_game_create(ls_game** game_ptr, const char* path, char** error_msg)
     if (ref) {
         game->attempt_count = json_integer_value(ref);
     }
-    //get finished count
+    // get finished count
     ref = json_object_get(json, "finished_count");
     if (ref) {
         game->finished_count = json_integer_value(ref);
@@ -648,7 +648,7 @@ int ls_timer_split(ls_timer* timer)
             ++timer->curr_split;
             // stop timer if last split
             if (timer->curr_split == timer->game->split_count) {
-                //Increment finished_count
+                // Increment finished_count
                 ++*timer->finished_count;
                 ls_timer_stop(timer);
                 ls_game_update_splits((ls_game*)timer->game, timer);

--- a/src/timer.c
+++ b/src/timer.c
@@ -215,6 +215,11 @@ int ls_game_create(ls_game** game_ptr, const char* path, char** error_msg)
     if (ref) {
         game->attempt_count = json_integer_value(ref);
     }
+    //get finished count
+    ref = json_object_get(json, "finished_count");
+    if (ref) {
+        game->finished_count = json_integer_value(ref);
+    }
     // get width
     ref = json_object_get(json, "width");
     if (ref) {
@@ -377,6 +382,10 @@ int ls_game_save(const ls_game* game)
         json_object_set_new(json, "attempt_count",
             json_integer(game->attempt_count));
     }
+    if (game->finished_count) {
+        json_object_set_new(json, "finished_count",
+            json_integer(game->finished_count));
+    }
     if (game->world_record) {
         ls_time_string_serialized(str, game->world_record);
         json_object_set_new(json, "world_record", json_string(str));
@@ -486,6 +495,7 @@ int ls_timer_create(ls_timer** timer_ptr, ls_game* game)
     }
     timer->game = game;
     timer->attempt_count = &game->attempt_count;
+    timer->finished_count = &game->finished_count;
     // alloc splits
     timer->split_times = calloc(timer->game->split_count,
         sizeof(long long));
@@ -638,6 +648,8 @@ int ls_timer_split(ls_timer* timer)
             ++timer->curr_split;
             // stop timer if last split
             if (timer->curr_split == timer->game->split_count) {
+                //Increment finished_count
+                ++*timer->finished_count;
                 ls_timer_stop(timer);
                 ls_game_update_splits((ls_game*)timer->game, timer);
             }

--- a/src/timer.h
+++ b/src/timer.h
@@ -12,6 +12,7 @@ struct ls_game {
     char* theme;
     char* theme_variant;
     int attempt_count;
+    int finished_count;
     int width;
     int height;
     long long world_record;
@@ -44,6 +45,7 @@ struct ls_timer {
     long long* best_segments;
     const ls_game* game;
     int* attempt_count;
+    int* finished_count;
 };
 typedef struct ls_timer ls_timer;
 


### PR DESCRIPTION
Adds a counter for number of finished runs with the total runs started counter. Increments on every finished run. 
![image](https://github.com/user-attachments/assets/5b95291d-e152-48eb-91f3-5ce1e9434a00)
