### PR TITLE
Update wording related to urn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <img src="libresplit.svg" width=43 align=top> [LibreSplit](https://libresplit.loomeh.is-a.dev)
 [![Discord](https://img.shields.io/discord/1381914148585078804?style=flat-square&logo=discord&label=LibreSplit&color=%237289da)](https://discord.gg/qbzD7MBjyw)
 
-LibreSplit brings auto splitting functionality to [urn](https://github.com/3snowp7im/urn) with Lua-based auto splitters that are easy to port from asl.
+LibreSplit is a speedrun timer based on [urn](https://github.com/3snowp7im/urn) that adds support for Lua-based auto splitters that are easy to port from ASL.
 
 <img src="https://github.com/wins1ey/LibreSplit/assets/34382191/2adfdae5-9a21-4bdf-a4c4-f1d5962a0b63" width=350>
 <img src="https://github.com/wins1ey/LibreSplit/assets/34382191/4455f57a-3d34-4fa3-9dff-2b342b6c56da" width=350>


### PR DESCRIPTION
This is a simple Readme PR that updates the wording related to LibreSplit's urn base.

The current wording seemed to give some people the impression that LibreSplit is a sort of add-on/plugin/tool for urn (or that urn is used as a dependency for LibreSplit), which it's not. This PR should help remove any confusion.
<img width="1260" height="470" alt="image" src="https://github.com/user-attachments/assets/3f344915-6cb2-4882-83ae-ad8494ca057c" />
