### PR TITLE
asl: Change maps cache cycles default to 1

### DIFF
--- a/docs/auto-splitters.md
+++ b/docs/auto-splitters.md
@@ -292,8 +292,8 @@ end
 # Experimental stuff
 ## `mapsCacheCycles`
 * When a readAddress that uses a memory map the biggest bottleneck is reading every line of `/proc/pid/maps` and checking if that line is the corresponding module. This option allows you to set for how many cycles the cache of that file should be used. The cache is global so it gets reset every x number of cycles.
-    * `0` (default): Disabled completely
-    * `1`: Enabled for the current cycle
+    * `0`: Disabled completely
+    * `1` (default): Enabled for the current cycle
     * `2`: Enabled for the current cycle and the next one
     * `3`: Enabled for the current cycle and the 2 next ones
     * You get the idea

--- a/src/auto-splitter.c
+++ b/src/auto-splitter.c
@@ -19,8 +19,8 @@
 
 char auto_splitter_file[PATH_MAX];
 int refresh_rate = 60;
-int maps_cache_cycles = 0; // 0=off, 1=current cycle, +1=multiple cycles
-int maps_cache_cycles_value = 0; // same as `maps_cache_cycles` but this one represents the current value rather than the reference from the script
+int maps_cache_cycles = 1; // 0=off, 1=current cycle, +1=multiple cycles
+int maps_cache_cycles_value = 1; // same as `maps_cache_cycles` but this one represents the current value that changes on each cycle rather than the reference from the script
 atomic_bool auto_splitter_enabled = true;
 atomic_bool call_start = false;
 atomic_bool call_split = false;


### PR DESCRIPTION
Changes the new default of memory maps cache from 0 (disabled) to 1 (current cycle only).
Makes it easier to make scripts with a lot of readAddress calls so people dont have to change this config to make scripts like these