### PR TITLE
asl: Reset lua state on run cancel

### DIFF
--- a/src/auto-splitter.c
+++ b/src/auto-splitter.c
@@ -22,6 +22,7 @@ int refresh_rate = 60;
 int maps_cache_cycles = 0; // 0=off, 1=current cycle, +1=multiple cycles
 int maps_cache_cycles_value = 0; // same as `maps_cache_cycles` but this one represents the current value rather than the reference from the script
 atomic_bool auto_splitter_enabled = true;
+atomic_bool auto_splitter_running = false;
 atomic_bool call_start = false;
 atomic_bool call_split = false;
 atomic_bool toggle_loading = false;

--- a/src/auto-splitter.h
+++ b/src/auto-splitter.h
@@ -5,6 +5,7 @@
 #include <stdatomic.h>
 
 extern atomic_bool auto_splitter_enabled;
+extern atomic_bool auto_splitter_running;
 extern atomic_bool call_start;
 extern atomic_bool call_split;
 extern atomic_bool toggle_loading;


### PR DESCRIPTION
Its a bit common for som vars to be left unchanged after a run cancel, so this resets the whole lua script on run cancel so every run is running the freshest state of the lua script as if nothing happened before the run cancel