### PR TITLE
ci: Fix publish wiki not having enough permissions

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -5,12 +5,18 @@ on:
       - docs/**
       - .github/workflows/publish-wiki.yml
 
+concurrency:
+  group: publish-wiki
+  cancel-in-progress: true
+permissions:
+  contents: write
+
 jobs:
   publish-wiki:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: Andrew-Chen-Wang/github-wiki-action@v4.3.0
+      - uses: Andrew-Chen-Wang/github-wiki-action@v5
         with:
           path: docs/
           token: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
Permissions for CI changed some time ago so wiki doesnt work anymore, also v5 of github-wiki-action released so use that just in case