### PR TITLE
ASL: Dont run start when running

### DIFF
--- a/src/auto-splitter.c
+++ b/src/auto-splitter.c
@@ -435,7 +435,7 @@ void run_auto_splitter()
             gameTime(L);
         }
 
-        if (start_exists) {
+        if (start_exists && !atomic_load(&run_started)) {
             start(L);
         }
 


### PR DESCRIPTION
According to LiveSplit documentation, the start action is only run when the timer is not running (either manually or by ingame time)
> The name of this action is start. Return true whenever you want the timer to start. Note that the start action will only be run if the timer hasn't been started (right after being reset, for example)