### PR TITLE
feat: Allow skipping split while timer is paused

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -739,7 +739,7 @@ int ls_timer_split(ls_timer* timer)
 
 int ls_timer_skip(ls_timer* timer)
 {
-    if (timer->running && timer->time > 0) {
+    if (timer->time > 0) {
         if (timer->curr_split < timer->game->split_count) {
             timer->split_times[timer->curr_split] = 0;
             timer->split_deltas[timer->curr_split] = 0;


### PR DESCRIPTION
Ported from `paoloose/urn`

This patch allows users to skip a split while the timer is paused (which I think may happen if the runner gets confused, pauses the timer and wants to take the time to re-align their splits with the game during a live run).