### PR TITLE
lasr: Add dialog when insufficient permissions

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,12 @@
+## LibreSplit was unable to read memory from the target process.
+* This is because in linux, a process cannot read the memory of another process that are unrelated
+* This fix should ONLY be used if you REALLY want to run the linux native version of a game with a linux native auto splitter
+* To fix this: **Run the game/program trough stam**
+* If the above doesnt work for some reason, keep reading
+### THIS WORKAROUND IS A HUGE SECURITY RISK, SO PLEASE ONLY DO IT IF ABSOLUTELY NECESSARY.
+#### You should give such permission only to programs you fully trust: A vulnerability in a program with such permission could give full system-wide access to malicious actors
+* Run `sudo setcap cap_sys_ptrace+ep /path/to/libresplit`
+    * Replace `path/to/libresplit` with the actual path of the libresplit binary
+* To revert back this capability run:
+* `sudo setcap -r /path/to/libresplit`
+    * Replace `path/to/libresplit` with the actual path of the libresplit binary

--- a/src/main.c
+++ b/src/main.c
@@ -1118,6 +1118,45 @@ static void* ls_auto_splitter(void* arg)
     return NULL;
 }
 
+static void dialog_response_cb(GtkWidget* dialog, gint response_id, gpointer user_data)
+{
+    if (response_id == GTK_RESPONSE_OK) {
+        gtk_show_uri_on_window(GTK_WINDOW(NULL), "https://github.com/LibreSplit/LibreSplit/wiki/troubleshooting", 0, NULL);
+    }
+    gtk_widget_destroy(dialog);
+}
+
+gboolean display_non_capable_mem_read_dialog(gpointer data)
+{
+    atomic_store(&auto_splitter_enabled, 0);
+    GtkWidget* dialog = gtk_message_dialog_new(
+        GTK_WINDOW(NULL),
+        GTK_DIALOG_DESTROY_WITH_PARENT,
+        GTK_MESSAGE_ERROR,
+        GTK_BUTTONS_NONE,
+        "LibreSplit was unable to read memory from the target process.\n"
+        "This is most probably due to insufficient permissions.\n"
+        "This only happens on linux native games/binaries.\n"
+        "Try running the game/program via steam.\n"
+        "Autosplitter has been disabled.\n"
+        "This warning will only show once until libresplit restarts.\n"
+        "Please read the troubleshooting documentation to solve this error without running as root if the above doesnt work\n"
+        "");
+
+    gtk_dialog_add_buttons(GTK_DIALOG(dialog),
+        "Close", GTK_RESPONSE_CANCEL,
+        "Open documentation", GTK_RESPONSE_OK, NULL);
+
+    g_signal_connect(dialog, "response", G_CALLBACK(dialog_response_cb), NULL);
+    gtk_widget_show_all(dialog);
+
+    gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
+
+    // Connect the response signal to the callback function
+    return FALSE; // False removes this function from the queue
+}
+
 int main(int argc, char* argv[])
 {
     check_directories();


### PR DESCRIPTION
<img width="526" height="238" alt="image" src="https://github.com/user-attachments/assets/4a63da43-3ac1-4283-aead-75fd588e0b38" />


On linux native titles, because of linux protection, we cant read from those processes, but there is many workarounds:
* Having the binary with the `CAP_SYS_PTRACE` capability
* Running libresplit as root (dear god no)
* Have the game run as a child process of libresplit
* Running the game trough steam (prefered option)

~~Realistically the only good solution is the first one, which i think should ONLY be done if the user wants to speedrun linux native title with the auto splitter working on the linux native version of said game
Enabling that capability is a HUGE security risk, as if any vulnerability happens in libresplit or the auto splitter then it could be exploited to read the memory of ANY process running by the user~~

This does not happen on wine, because wine sets every process it creates as "dumpable", this is done to allow windows debugger to work normally and read the memory of other processes under the same wine prefix

The dialog will only show once until libresplit is restarted like it says, and only for when it detects a permission error, after the dialog the program will ignore it and work as usual

Also fix memory errors not being handled for strings