### PR TITLE
ci: Add AppImage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
                   sudo update-alternatives --set gcc /usr/bin/gcc-15
 
             - name: "Configure"
-              run: meson setup build -Dbuildtype=release
+              run: meson setup build -Dbuildtype=release -Dprefix=/usr
 
             - name: "Build"
               run: meson compile -C build
@@ -46,3 +46,70 @@ jobs:
               with:
                   name: LibreSplit-${{ env.build_number }}-${{ env.git_short_sha }}
                   path: release/
+
+    appimage:
+        runs-on: ubuntu-24.04
+        name: Build AppImage
+        needs: tests
+        steps:
+            - name: "Checkout"
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: "Download build artifacts"
+              uses: actions/download-artifact@v4
+              with:
+                  pattern: LibreSplit-*
+                  merge-multiple: true
+
+            - name: "Install AppImage dependencies"
+              run: |
+                  sudo apt -y update
+                  sudo apt -y install desktop-file-utils libluajit-5.1-dev
+
+            - name: Set Build number
+              shell: bash
+              run: echo "build_number=$(git rev-list HEAD --count)" >> $GITHUB_ENV
+
+            - name: Compute git short sha
+              shell: bash
+              run: echo "git_short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+            - name: "Setup AppDir structure"
+              run: |
+                  mkdir -p AppDir/usr/bin
+                  mkdir -p AppDir/usr/share/applications
+                  mkdir -p AppDir/usr/share/libresplit
+                  mkdir -p AppDir/usr/share/pixmaps
+                  mkdir -p AppDir/usr/share/doc/libresplit
+                  mkdir -p AppDir/usr/share/licenses/libresplit
+
+                  cp libresplit AppDir/usr/bin/
+                  chmod +x AppDir/usr/bin/libresplit
+
+                  cp assets/default_settings.json AppDir/usr/share/libresplit/
+                  cp assets/libresplit.desktop AppDir/usr/share/applications/
+
+                  cp assets/icons/libresplit-256.png AppDir/usr/share/pixmaps/libresplit.png
+
+                  cp LICENSE AppDir/usr/share/licenses/libresplit/
+
+                  # Create AppImage-compatible desktop entry at root
+                  cp assets/libresplit.desktop AppDir/
+                  cp assets/icons/libresplit-256.png AppDir/libresplit.png
+
+            - name: "Download linuxdeploy"
+              run: |
+                  wget -O linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/latest/download/linuxdeploy-x86_64.AppImage
+                  chmod +x linuxdeploy-x86_64.AppImage
+
+            - name: "Create AppImage"
+              run: |
+                  ./linuxdeploy-x86_64.AppImage --appdir AppDir --output appimage
+
+            - name: "Upload AppImage"
+              uses: actions/upload-artifact@v4
+              with:
+                  path: LibreSplit-x86_64.AppImage
+                  name: LibreSplit-${{ env.build_number }}-${{ env.git_short_sha }}-x86_64.AppImage

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ build/
 .vscode/
 .cache/
 compile_commands.json
+
+# AppImage stuff
+AppDir/
+*.AppImage

--- a/meson.build
+++ b/meson.build
@@ -16,13 +16,12 @@ luajit = dependency('luajit')
 x11 = dependency('x11')
 jansson = dependency('jansson')
 
-
 configure_file(
-  input: 'src/config.h.in',
-  output: 'config.h',
-  configuration: {
-    'DEFAULT_CONFIG_PATH': get_option('prefix') / get_option('datadir') / meson.project_name() / 'default_settings.json'
-  }
+    input: 'src/config.h.in',
+    output: 'config.h',
+    configuration: {
+        'DEFAULT_CONFIG_PATH': get_option('prefix') / get_option('datadir') / meson.project_name() / 'default_settings.json',
+    },
 )
 
 executable(

--- a/src/settings.c
+++ b/src/settings.c
@@ -11,9 +11,25 @@
 
 #include "settings.h"
 
+/**
+ * Gets the default config path, considering APPDIR if set.
+ *
+ * @param out_path A buffer to store the resulting path, which may be prepended with APPDIR if set for AppImages
+ */
+void get_default_config_path(char* out_path)
+{
+    out_path[0] = '\0';
+    if (getenv("APPDIR")) {
+        strcat(out_path, getenv("APPDIR"));
+    }
+    strcat(out_path, DEFAULT_CONFIG_PATH);
+}
+
 void copy_default_config(const char* dest_path)
 {
-    FILE* src = fopen(DEFAULT_CONFIG_PATH, "r");
+    char default_config_path[PATH_MAX];
+    get_default_config_path(default_config_path);
+    FILE* src = fopen(default_config_path, "r");
     FILE* dest = fopen(dest_path, "w");
 
     if (!src || !dest) {
@@ -113,7 +129,10 @@ json_t* _load_from_json(const char* settings_path)
 
 json_t* _load_default_settings()
 {
-    return _load_from_json(DEFAULT_CONFIG_PATH);
+
+    char default_config_path[PATH_MAX];
+    get_default_config_path(default_config_path);
+    return _load_from_json(default_config_path);
 }
 
 json_t* _load_user_settings()


### PR DESCRIPTION
Adds AppImage output to CI, afaik everything works but there could be edge cases
For default config, it will detect at runtime if its in an appimage or not with the APPDIR env var

Fixes: https://github.com/LibreSplit/LibreSplit/issues/67