### PR TITLE
Add ctl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
                   mkdir release
                   cp -r assets release/
                   cp -r build/libresplit release/
+                  cp -r build/libresplit-ctl release/
                   cp README.md release/
                   cp LICENSE release/
 
@@ -86,7 +87,9 @@ jobs:
                   mkdir -p AppDir/usr/share/licenses/libresplit
 
                   cp libresplit AppDir/usr/bin/
+                  cp libresplit-ctl AppDir/usr/bin/
                   chmod +x AppDir/usr/bin/libresplit
+                  chmod +x AppDir/usr/bin/libresplit-ctl
 
                   cp assets/default_settings.json AppDir/usr/share/libresplit/
                   cp assets/libresplit.desktop AppDir/usr/share/applications/
@@ -97,6 +100,9 @@ jobs:
 
                   # Create AppImage-compatible desktop entry at root
                   cp assets/libresplit.desktop AppDir/
+                  sed -i 's/^Exec=.*/Exec=AppRun/' AppDir/libresplit.desktop
+                  cp assets/appimage.sh AppDir/AppRun
+                  chmod +x AppDir/AppRun
                   cp assets/icons/libresplit-256.png AppDir/libresplit.png
 
             - name: "Download linuxdeploy"
@@ -106,7 +112,7 @@ jobs:
 
             - name: "Create AppImage"
               run: |
-                  ./linuxdeploy-x86_64.AppImage --appdir AppDir --output appimage
+                  ./linuxdeploy-x86_64.AppImage --appdir AppDir --desktop-file AppDir/libresplit.desktop --icon-file AppDir/libresplit.png --output appimage
 
             - name: "Upload AppImage"
               uses: actions/upload-artifact@v4

--- a/assets/appimage.sh
+++ b/assets/appimage.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+    exec "$APPDIR/usr/bin/libresplit"
+else
+    exec "$APPDIR/usr/bin/libresplit-ctl" "$@"
+fi

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,8 @@ executable(
     'libresplit',
     [
         'src/main.c',
+        'src/shared.c',
+        'src/server.c',
         'src/auto-splitter.c',
         'src/bind.c',
         'src/memory.c',
@@ -50,6 +52,13 @@ executable(
         '-DDATADIR="' + get_option('datadir') + '"',
         '-Werror',
     ],
+    install: true,
+)
+
+executable(
+    'libresplit-ctl',
+    'src/ctl.c',
+    'src/shared.c',
     install: true,
 )
 

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -1,0 +1,113 @@
+#include "shared.h"
+
+#include <arpa/inet.h>
+#include <endian.h>
+#include <linux/limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+void print_help()
+{
+    printf("Available commands:\n");
+    printf("  startorsplit  - Start the timer/Split if timer is running\n");
+    printf("  stoporreset   - Stop the timer/Reset the timer if its stopped\n");
+    printf("  cancel        - Cancel the run\n");
+    printf("  unsplit       - Unsplit the timer\n");
+    printf("  skipsplit     - Skip the current split\n");
+    printf("  exit          - Closes LibreSplit\n");
+    printf("  help          - Show this help message\n");
+}
+
+bool sendToLibreSplit(const CTLCommand cmd)
+{
+    char runtime_dir[PATH_MAX - 17];
+    getXDGruntimeDir(runtime_dir, sizeof(runtime_dir));
+    if (strlen(runtime_dir) == 0) {
+        fprintf(stderr, "Failed to get LibreSplit socket path.\n");
+        return false;
+    }
+
+    char socket_path[PATH_MAX];
+    snprintf(socket_path, PATH_MAX, "%s/%s", runtime_dir, LIBRESPLIT_SOCK_NAME);
+
+    int sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (sockfd == -1) {
+        perror("Failed to create socket");
+        return false;
+    }
+
+    struct sockaddr_un addr = { 0 };
+    memset(&addr, 0, sizeof(struct sockaddr_un));
+    addr.sun_family = AF_UNIX;
+    strcpy(addr.sun_path, socket_path);
+
+    if (connect(sockfd, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
+        perror("Failed to connect to LibreSplit socket");
+        close(sockfd);
+        return false;
+    }
+
+    // We can send arbitrarily long messages, but for now we only need to send a single byte
+    // Could be useful for future extensions though
+    CTLMessage* ctl_msg = (CTLMessage*)malloc(sizeof(CTLMessage) + sizeof(cmd));
+    ctl_msg->length = htonl(sizeof(cmd));
+    memcpy(ctl_msg->message, &cmd, sizeof(cmd));
+
+    int written = write(sockfd, ctl_msg, sizeof(CTLMessage) + sizeof(cmd));
+    if (written != sizeof(CTLMessage) + sizeof(cmd)) {
+        fprintf(stderr, "Failed to send command to LibreSplit.\n");
+        close(sockfd);
+        free(ctl_msg);
+        return false;
+    }
+    free(ctl_msg);
+    close(sockfd);
+
+    return true;
+}
+
+int main(int argc, char* argv[])
+{
+    if (argc != 2) {
+        fprintf(stderr, "Error: This program accepts exactly 1 argument.\n");
+        fprintf(stderr, "Try 'help' for a list of commands.\n");
+        return 1;
+    }
+
+    const char* cmd = argv[1];
+
+    if (strcmp(cmd, "help") == 0) {
+        print_help();
+        return 0;
+    }
+
+    bool success = false;
+
+    if (strcmp(cmd, "startorsplit") == 0) {
+        success = sendToLibreSplit(CTL_CMD_START_SPLIT);
+    } else if (strcmp(cmd, "stoporreset") == 0) {
+        success = sendToLibreSplit(CTL_CMD_STOP_RESET);
+    } else if (strcmp(cmd, "cancel") == 0) {
+        success = sendToLibreSplit(CTL_CMD_CANCEL);
+    } else if (strcmp(cmd, "unsplit") == 0) {
+        success = sendToLibreSplit(CTL_CMD_UNSPLIT);
+    } else if (strcmp(cmd, "skipsplit") == 0) {
+        success = sendToLibreSplit(CTL_CMD_SKIP);
+    } else if (strcmp(cmd, "exit") == 0) {
+        success = sendToLibreSplit(CTL_CMD_EXIT);
+    } else {
+        fprintf(stderr, "Unknown command: %s\n", cmd);
+        fprintf(stderr, "Try 'help' for a list of valid commands.\n");
+        return 1;
+    }
+
+    if (!success) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/server.c
+++ b/src/server.c
@@ -1,0 +1,163 @@
+#include "shared.h"
+
+#include <arpa/inet.h>
+#include <gtk/gtk.h>
+#include <linux/limits.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+extern atomic_bool exit_requested;
+
+// Structure to pass command data to main thread
+typedef struct {
+    CTLCommand command;
+} CommandData;
+
+// External functions from main.c to handle commands
+extern void handle_ctl_command(CTLCommand command);
+
+// Command execution function that runs on the main thread
+static gboolean execute_command_on_main_thread(gpointer data)
+{
+    CommandData* cmd_data = (CommandData*)data;
+
+    // Call the main.c function to handle the command
+    handle_ctl_command(cmd_data->command);
+
+    g_free(cmd_data);
+    return FALSE; // Remove from idle queue
+}
+
+// Forward declarations for command handlers
+
+int receive_message(int sockfd, CTLMessage** out)
+{
+
+    // Read header (blocking)
+    uint32_t len = 0;
+    ssize_t n = read(sockfd, &len, sizeof(len));
+    if (n == 0)
+        return 1; // client closed connection immediately
+    len = ntohl(len);
+    if (n != sizeof(len))
+        return -1;
+
+    CTLMessage* msg = malloc(sizeof(CTLMessage) + len);
+    msg->length = len;
+
+    size_t received = 0;
+    while (received < len) {
+        n = read(sockfd, msg->message + received, len - received);
+        if (n <= 0) {
+            free(msg);
+            return -1;
+        }
+        received += n;
+    }
+
+    *out = msg;
+    return 0;
+}
+
+void* ls_ctl_server(void* arg)
+{
+    char runtime_dir[PATH_MAX - 17];
+    getXDGruntimeDir(runtime_dir, sizeof(runtime_dir));
+    if (strlen(runtime_dir) == 0) {
+        fprintf(stderr, "Failed to get LibreSplit socket path.\n");
+        return 0;
+    }
+
+    char socket_path[PATH_MAX];
+    snprintf(socket_path, PATH_MAX, "%s/%s", runtime_dir, LIBRESPLIT_SOCK_NAME);
+
+    int server_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (server_fd < 0) {
+        perror("Failed to create socket");
+        return 0;
+    }
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strcpy(addr.sun_path, socket_path);
+
+    unlink(socket_path);
+
+    if (bind(server_fd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        perror("Failed to bind socket");
+        close(server_fd);
+        return 0;
+    }
+
+    if (listen(server_fd, 20) < 0) { // backlog for many short connections
+        perror("Failed to listen on socket");
+        close(server_fd);
+        return 0;
+    }
+
+    while (1) {
+        fd_set fds;
+        FD_ZERO(&fds);
+        FD_SET(server_fd, &fds);
+
+        struct timeval tv;
+        tv.tv_sec = 0;
+        tv.tv_usec = 50 * 1000; // 50ms
+
+        int ret = select(server_fd + 1, &fds, NULL, NULL, &tv);
+
+        if (ret < 0) {
+            perror("select failed");
+            continue;
+        }
+
+        if (ret == 0) { // Timeout
+            if (atomic_load(&exit_requested)) {
+                break;
+            }
+        }
+
+        // If we reach here, the listening socket is readable
+        if (FD_ISSET(server_fd, &fds)) {
+
+            int client_fd = accept(server_fd, NULL, NULL);
+            if (client_fd < 0) {
+                perror("Failed to accept client connection");
+                continue; // do not stop the server on accept errors
+            }
+
+            CTLMessage* msg = NULL;
+            int result = receive_message(client_fd, &msg);
+
+            if (result == 0) {
+                if (msg->length == sizeof(CTLCommand)) {
+                    CTLCommand command = *(CTLCommand*)msg->message;
+                    CommandData* cmd_data = g_malloc(sizeof(CommandData));
+                    cmd_data->command = command;
+
+                    // Queue command execution on main thread
+                    g_idle_add(execute_command_on_main_thread, cmd_data);
+                } else {
+                    printf("Invalid message length: %u (expected %zu)\n", msg->length, sizeof(CTLCommand));
+                }
+
+                free(msg);
+            } else {
+                printf("Client closed without sending a full message.\n");
+            }
+
+            close(client_fd);
+        }
+    }
+
+    close(server_fd);
+    unlink(socket_path);
+
+    return 0;
+}

--- a/src/server.h
+++ b/src/server.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void* ls_ctl_server(void* arg);

--- a/src/shared.c
+++ b/src/shared.c
@@ -1,0 +1,20 @@
+#include "shared.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+void getXDGruntimeDir(char* buffer, size_t size)
+{
+    const char* xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
+    buffer[0] = '\0';
+    if (xdg_runtime_dir) {
+        strncpy(buffer, xdg_runtime_dir, size - 1);
+        buffer[size - 1] = '\0';
+        return;
+    }
+
+    const int uid = getuid();
+    snprintf(buffer, size, "/run/user/%d", uid);
+}

--- a/src/shared.h
+++ b/src/shared.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define LIBRESPLIT_SOCK_NAME "libresplit.sock"
+
+void getXDGruntimeDir(char* buffer, size_t size);
+
+typedef enum : uint8_t {
+    CTL_CMD_START_SPLIT,
+    CTL_CMD_STOP_RESET,
+    CTL_CMD_CANCEL,
+    CTL_CMD_UNSPLIT,
+    CTL_CMD_SKIP,
+    CTL_CMD_EXIT,
+} CTLCommand;
+
+typedef struct __attribute__((__packed__)) CTLMessage {
+    uint32_t length; // Size of message in bytes
+    uint8_t message[];
+} CTLMessage;


### PR DESCRIPTION
Adds a new binary `libresplit-ctl`, which talks to the main libresplit instance to control the timer, for cases where the game and libresplit arent running on the same system
Also works as a workaround for wayland keybinds since you can setup global hotkeys in your desktop to launch libresplit-ctl

For appimage:
Both binaries work as one, launching without arguments (double click too) will open the main libresplit program, but running the appimage with any arguments will use ctl instead, like so:
```
./libresplit.appimage (launches the normal libresplit)
./libresplit.appimage help (gives you info on what commands are available)
./libresplit.appimage start-split (will start or split the timer)
```

Fixes: https://github.com/LibreSplit/LibreSplit/issues/98

TODO: 
- [x] Add at least some documentation on ctl