### PR TITLE
Enable -Wall and some other warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -52,6 +52,10 @@ executable(
         '-DPREFIX="' + get_option('prefix') + '"',
         '-DDATADIR="' + get_option('datadir') + '"',
         '-Werror',
+        '-Wall',
+        '-Wbad-function-cast',
+        '-Wsign-compare',
+        '-Wpedantic',
     ],
     install: true,
 )

--- a/src/auto-splitter.c
+++ b/src/auto-splitter.c
@@ -220,7 +220,7 @@ bool call_va(lua_State* L, const char* func, const char* sig, ...)
                         printf("function '%s' wrong result type, expected int\n", func);
                         return false;
                     }
-                    *va_arg(vl, int*) = (int)lua_tonumber(L, nres);
+                    *va_arg(vl, int*) = lua_tointeger(L, nres);
                     break;
 
                 case 's': /* string result */

--- a/src/main.c
+++ b/src/main.c
@@ -75,7 +75,7 @@ struct _LSAppWindowClass {
     GtkApplicationWindowClass parent_class;
 };
 
-G_DEFINE_TYPE(LSAppWindow, ls_app_window, GTK_TYPE_APPLICATION_WINDOW);
+G_DEFINE_TYPE(LSAppWindow, ls_app_window, GTK_TYPE_APPLICATION_WINDOW)
 
 static Keybind parse_keybind(const gchar* accelerator)
 {
@@ -803,7 +803,7 @@ struct _LSAppClass {
     GtkApplicationClass parent_class;
 };
 
-G_DEFINE_TYPE(LSApp, ls_app, GTK_TYPE_APPLICATION);
+G_DEFINE_TYPE(LSApp, ls_app, GTK_TYPE_APPLICATION)
 
 static void open_activated(GSimpleAction* action,
     GVariant* parameter,

--- a/src/process.c
+++ b/src/process.c
@@ -42,7 +42,7 @@ uintptr_t find_base_address(const char* module)
 {
     const char* module_to_grep = module == 0 ? process.name : module;
 
-    for (int32_t i = 0; i < p_maps_cache_size; i++) {
+    for (uint32_t i = 0; i < p_maps_cache_size; i++) {
         const char* name = p_maps_cache[i].name;
         if (strstr(name, module_to_grep) != NULL) {
             return p_maps_cache[i].start;
@@ -82,7 +82,7 @@ uint64_t get_module_size(const char* module)
     const char* module_to_grep = module == 0 ? process.name : module;
 
     // Check the cache
-    for (int32_t i = 0; i < p_maps_cache_size; i++) {
+    for (uint32_t i = 0; i < p_maps_cache_size; i++) {
         const char* name = p_maps_cache[i].name;
         if (strstr(name, module_to_grep) != NULL) {
             return p_maps_cache[i].size;


### PR DESCRIPTION
@Penaz91 got the idea of enabling some warnings
-Wall was supposed to already be there from the beggining
bad-function-cast only needed one change in call_va for the integer path, which only used by gameTime, so its fine to change it to interger instead of number
sign-compare is very minor and shouldnt bring any problems since it only was being annoying about maps cache index
pedantic didnt say anything (for now)

Keeping in mind all this warning enabling only affects main libresplit program, ctl is using defaults, only some warnings are enabled there, could be changed in the future