### PR TITLE
lasr: Rework maps caching to use ioctl

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,13 @@ if get_option('buildtype') == 'debug'
     add_project_arguments('-DDEBUG', language: 'cpp')
 endif
 
+cc = meson.get_compiler('c')
+has_procmap_ioctl = cc.has_header_symbol('linux/fs.h', 'PROCMAP_QUERY')
+ioctl_maps = get_option('ioctl_maps').enable_auto_if(has_procmap_ioctl)
+if ioctl_maps.enabled()
+    add_project_arguments('-DIOCTL_MAPS', language: 'c')
+endif
+
 threads = dependency('threads')
 gtk = dependency('gtk+-3.0')
 luajit = dependency('luajit')
@@ -33,6 +40,7 @@ executable(
         # LASR
         'src/lasr/auto-splitter.c',
         'src/lasr/utils.c',
+        'src/lasr/maps/maps.c',
         'src/lasr/functions/bitwise.c',
         'src/lasr/functions/getBaseAddress.c',
         'src/lasr/functions/getModuleSize.c',
@@ -78,6 +86,7 @@ executable(
 message('prefix: ' + get_option('prefix')) # /usr/local by default
 message('datadir: ' + get_option('datadir')) # share by default
 message('buildtype: ' + get_option('buildtype'))
+message('ioctl_maps: ' + ioctl_maps.enabled().to_string())
 
 install_data(
     'assets/libresplit.desktop',

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,6 @@
+option(
+    'ioctl_maps',
+    type: 'feature',
+    value: 'auto',
+    description: 'Support ioctl calls to fetch memory maps instead of reading /proc/[pid]/maps.',
+)

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -4,6 +4,7 @@
  */
 #include "auto-splitter.h"
 
+#include "./maps/maps.h"
 #include "functions.h"
 #include "utils.h"
 
@@ -30,6 +31,12 @@ atomic_llong game_time_value = 0; /*!< The in-game time value, in milliseconds *
  * 0=off, 1=current cycle, +1=multiple cycles
  */
 int maps_cache_cycles = 1;
+/**
+ * Same as `maps_cache_cycles` but this one represents the current value
+ * that changes on each cycle rather than the reference from the script
+ */
+int maps_cache_cycles_value = 1; /*!< The number of cycles the cache is active for */
+
 atomic_bool auto_splitter_enabled = true; /*!< Defines if the auto splitter is enabled */
 atomic_bool auto_splitter_running = false; /*!< Defines if the auto splitter is running */
 atomic_bool call_start = false; /*!< True if the auto splitter is requesting for a run to start */
@@ -529,7 +536,7 @@ void run_auto_splitter()
         // Clear the memory maps cache if needed
         maps_cache_cycles_value--;
         if (maps_cache_cycles_value < 1) {
-            p_maps_cache_size = 0; // We dont need to "empty" the list as the elements after index 0 are considered invalid
+            maps_clearCache();
             maps_cache_cycles_value = maps_cache_cycles;
             // printf("Cleared maps cache\n");
         }

--- a/src/lasr/functions/getModuleSize.c
+++ b/src/lasr/functions/getModuleSize.c
@@ -1,51 +1,11 @@
 #include "getModuleSize.h"
 
 #include "../utils.h"
+#include "src/lasr/maps/maps.h"
 
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-
-uint64_t get_module_size_from_map(const char* module)
-{
-    const char* module_to_grep = module == 0 ? process.name : module;
-
-    // Check the cache
-    for (uint32_t i = 0; i < p_maps_cache_size; i++) {
-        const char* name = p_maps_cache[i].name;
-        if (strstr(name, module_to_grep) != NULL) {
-            return p_maps_cache[i].size;
-        }
-    }
-
-    // If not in cache, read the maps
-    char path[22]; // 22 is the maximum length the path can be (strlen("/proc/4294967296/maps"))
-
-    snprintf(path, sizeof(path), "/proc/%d/maps", process.pid);
-
-    FILE* f = fopen(path, "r");
-
-    if (f) {
-        char current_line[PATH_MAX + 100];
-        while (fgets(current_line, sizeof(current_line), f) != NULL) {
-            if (strstr(current_line, module_to_grep) == NULL)
-                continue;
-            fclose(f);
-            ProcessMap map;
-            bool parsed = parseMapsLine(current_line, &map);
-            if (maps_cache_cycles_value != 0 && p_maps_cache_size < MAPS_CACHE_MAX_SIZE) {
-                if (parsed) {
-                    p_maps_cache[p_maps_cache_size] = map;
-                    p_maps_cache_size++;
-                }
-            }
-            return map.size;
-        }
-        fclose(f);
-    }
-    printf("Couldn't find the module\n");
-    return 0;
-}
 
 /**
  * The lua getModuleSize() function.
@@ -57,27 +17,27 @@ uint64_t get_module_size_from_map(const char* module)
  */
 int getModuleSize(lua_State* L)
 {
-    if (lua_gettop(L) == 0) {
-        // Called without argument
-        uint64_t size = get_module_size_from_map(NULL);
-        lua_pushinteger(L, (lua_Integer)size);
-        return 1;
-    }
-    if (lua_isnil(L, 1)) {
-        // Called with "nil" as argument
-        uint64_t size = get_module_size_from_map(NULL);
-        lua_pushinteger(L, (lua_Integer)size);
-        return 1;
-    }
-    if (!lua_isstring(L, 1)) {
+    char module_name[PATH_MAX];
+
+    if (lua_gettop(L) == 0 || lua_isnil(L, 1)) {
+        strncpy(module_name, process.name, sizeof(module_name) - 1);
+    } else if (lua_isstring(L, 1)) {
+        const char* str = lua_tostring(L, 1);
+        strncpy(module_name, str, sizeof(module_name) - 1);
+    } else {
         // Called with invalid non-string parameter
         printf("[getModuleSize] Module name must be a string or nil (for the main module)");
         lua_pushnil(L);
         return 1;
     }
-    // Called with a module name (string)
-    const char* module_name = lua_tostring(L, 1);
-    uint64_t size = get_module_size_from_map(module_name);
-    lua_pushinteger(L, (lua_Integer)size);
+
+    ProcessMap map;
+    const bool found = maps_findMapByName(module_name, &map);
+    if (found) {
+        lua_pushinteger(L, (lua_Integer)map.size);
+        return 1;
+    }
+    lua_pushnil(L);
+    printf("[getModuleSize] Cannot find module with name \"%s\"", module_name);
     return 1;
 }

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -43,6 +43,7 @@ void log_error(const char* format, ...)
  */
 ProcessMap* get_memory_regions(pid_t pid, int* count)
 {
+    // TODO: Convert this function to use maps.c functions
     char maps_path[256];
     if (snprintf(maps_path, sizeof(maps_path), "/proc/%d/maps", pid) < 0) {
         HANDLE_ERROR("Failed to create maps path");

--- a/src/lasr/maps/maps.c
+++ b/src/lasr/maps/maps.c
@@ -1,0 +1,309 @@
+#include "maps.h"
+
+#include "src/lasr/utils.h"
+
+#include <fcntl.h>
+#include <linux/fs.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+ProcessMap* maps_cache = NULL; // Array of cached maps
+size_t maps_cache_size = 0; // Number of cached maps
+
+// Use blocks to build the maps cache incrementally
+// This allows the cache to be built without knowing the total size in advance
+// Also makes it easier to manage memory so we dont overshoot in alloc size and grows predictably
+static MapsBlock* head = NULL; // Head of blocks
+static MapsBlock* current = NULL; // Current block being filled
+
+/**
+ * Append a ProcessMap entry to the internal block list.
+ * @param e The ProcessMap entry to append.
+ */
+static void append_entry(ProcessMap e)
+{
+    if (!current || current->used == MAPS_CACHE_BLOCK_SIZE) {
+        MapsBlock* new_block = malloc(sizeof(MapsBlock));
+        if (!new_block) {
+            perror("Failed to allocate memory for maps block");
+            exit(EXIT_FAILURE);
+        }
+
+        new_block->used = 0;
+        new_block->next = NULL;
+
+        if (!head)
+            head = new_block;
+        else
+            current->next = new_block;
+
+        current = new_block;
+    }
+
+    current->entries[current->used++] = e;
+}
+/**
+ * Flatten the internal linked list of MapsBlock into a contiguous array.
+ * @param out_count Pointer to a size_t which receives the number of entries.
+ *
+ * Internal linked list of MapsBlock is left untouched, still being valid
+ *
+ * Returns: pointer to malloc'd array of ProcessMap entries.
+ */
+static ProcessMap* maps_flatten(size_t* out_count)
+{
+    size_t total = 0;
+    for (MapsBlock* b = head; b; b = b->next)
+        total += b->used;
+
+    ProcessMap* arr = malloc(total * sizeof(ProcessMap));
+    if (!arr)
+        abort();
+
+    size_t idx = 0;
+    for (MapsBlock* b = head; b; b = b->next) {
+        memcpy(&arr[idx], b->entries, b->used * sizeof(ProcessMap));
+        idx += b->used;
+    }
+
+    *out_count = total;
+    return arr;
+}
+
+/**
+ * Free and clear the maps cache and internal block list.
+ *
+ * For use before rebuilding the cache from scratch
+ *
+ * Frees all allocated MapsBlock structures used for incremental collection
+ * and frees the flattened `maps_cache` array if present. Resets the
+ * `head`, `current`, and `maps_cache_size` to their empty states.
+ */
+void maps_clearCache(void)
+{
+    MapsBlock* b = head;
+    while (b) {
+        MapsBlock* next = b->next;
+        free(b);
+        b = next;
+    }
+    head = NULL;
+    current = NULL;
+
+    if (maps_cache) {
+        free(maps_cache);
+        maps_cache = NULL;
+        maps_cache_size = 0;
+    }
+}
+
+#ifdef IOCTL_MAPS
+/**
+ * Check if PROCMAP_QUERY ioctl is supported on the current system.
+ *
+ * Opens /proc/self/maps and attempts to issue a PROCMAP_QUERY ioctl.
+ * If the ioctl returns >= 0, it is supported.
+ *
+ * @return true if supported, false otherwise.
+ */
+static bool maps_ioctlSupported()
+{
+    const char* path = "/proc/self/maps";
+    int f = open(path, O_RDONLY);
+    if (f < 0) {
+        return false;
+    }
+
+    struct procmap_query q = { 0 };
+    q.size = sizeof(q);
+    q.query_flags = PROCMAP_QUERY_COVERING_OR_NEXT_VMA;
+    q.query_addr = 0;
+
+    int ret = ioctl(f, PROCMAP_QUERY, &q);
+    close(f);
+    return ret >= 0;
+}
+
+/**
+ * Populate the maps cache by querying the target process maps.
+ *
+ * uses `ioctl(PROCMAP_QUERY)` in a loop to collect all VMA information.
+ * Entries are collected into internal blocks and then flattened into `maps_cache`.
+ *
+ * @return Number of maps collected
+ */
+static size_t maps_getAll_ioctl(void)
+{
+    char path[22]; // 22 is the maximum length the path can be (strlen("/proc/4294967296/maps"))
+    snprintf(path, sizeof(path), "/proc/%d/maps", process.pid);
+    int f = open(path, O_RDONLY);
+    if (f >= 0) {
+        struct procmap_query q = { 0 };
+        char map_name[PATH_MAX];
+        q.size = sizeof(q);
+        q.query_flags = PROCMAP_QUERY_COVERING_OR_NEXT_VMA;
+        q.query_addr = 0;
+        maps_clearCache();
+        for (;;) {
+            q.vma_name_addr = (uintptr_t)map_name;
+            q.vma_name_size = sizeof(map_name);
+            int ret = ioctl(f, PROCMAP_QUERY, &q);
+            if (ret < 0) {
+                break;
+            }
+            ProcessMap map = {
+                .start = q.vma_start,
+                .end = q.vma_end,
+                .size = q.vma_end - q.vma_start,
+            };
+            strncpy(map.name, q.vma_name_addr ? map_name : "", sizeof(map.name) - 1);
+            append_entry(map);
+            // Advance past this mapping
+            q.query_addr = q.vma_end;
+        }
+        close(f);
+        maps_cache = maps_flatten(&maps_cache_size);
+    }
+    return maps_cache_size;
+}
+
+#endif
+
+/**
+ * Parse a single line from /proc/[pid]/maps into a ProcessMap structure.
+ * @param line The line to parse.
+ * @param map Pointer to ProcessMap to receive the parsed data.
+ *
+ * @return true on successful parse, false otherwise.
+ */
+static bool maps_parseMapsLine(const char* line, ProcessMap* map)
+{
+    uint64_t size;
+    char mode[8];
+    unsigned long offset;
+    unsigned int major_id, minor_id, node_id;
+
+    // Thank you kernel source code
+    int sscanf_res = sscanf(line, "%lx-%lx %7s %lx %u:%u %u %s", &map->start,
+        &map->end, mode, &offset, &major_id,
+        &minor_id, &node_id, map->name);
+    if (!sscanf_res)
+        return false;
+
+    // Calculate the map size
+    size = map->end - map->start;
+    map->size = size;
+    return true;
+}
+
+/**
+ * Populate the maps cache by reading /proc/[pid]/maps.
+ *
+ * @return Number of maps collected
+ */
+static size_t maps_getAll_legacy(void)
+{
+    char path[22]; // 22 is the maximum length the path can be (strlen("/proc/4294967296/maps"))
+
+    snprintf(path, sizeof(path), "/proc/%d/maps", process.pid);
+
+    FILE* f = fopen(path, "r");
+
+    if (f) {
+        char current_line[PATH_MAX + 100];
+        maps_clearCache();
+        while (fgets(current_line, sizeof(current_line), f) != NULL) {
+            ProcessMap map;
+            if (maps_parseMapsLine(current_line, &map)) {
+                append_entry(map);
+            } else {
+                printf("Failed to parse maps line: %s\n", current_line);
+            }
+        }
+        fclose(f);
+        maps_cache = maps_flatten(&maps_cache_size);
+    }
+    return maps_cache_size;
+}
+
+#ifdef IOCTL_MAPS
+static size_t maps_getAll_init(void);
+static size_t (*maps_getAll_var)(void) = maps_getAll_init;
+#else
+static size_t (*maps_getAll_var)(void) = maps_getAll_legacy;
+#endif
+
+#ifdef IOCTL_MAPS
+/**
+ * Initialize the maps_getAll function pointer based on ioctl support.
+ * Also calls the selected function to populate the maps cache initially.
+ * @return Number of maps collected
+ */
+static size_t maps_getAll_init(void)
+{
+    if (maps_ioctlSupported()) {
+        maps_getAll_var = maps_getAll_ioctl;
+        printf("PROCMAP_QUERY is supported, using ioctl method for maps retrieval.\n");
+    } else {
+        maps_getAll_var = maps_getAll_legacy;
+        printf("PROCMAP_QUERY is not supported, using legacy method for maps retrieval.\n");
+    }
+    return (*maps_getAll_var)();
+}
+#endif
+
+/**
+ * Get all process maps and populate the maps cache.
+ *
+ * @return Number of maps collected
+ */
+size_t maps_getAll(void)
+{
+    return (*maps_getAll_var)();
+}
+
+/**
+ * Find a map by substring match on its name.
+ * @param name Substring to search for (must not be NULL).
+ * @param out_map Pointer to ProcessMap to receive result on success.
+ *
+ * Searches the current `maps_cache` for an entry whose name contains
+ * the provided substring. If no entry is found, the cache is refreshed via
+ * `maps_getAll()` and the search is retried. On success the matching
+ * ProcessMap is copied into `out_map`
+ *
+ * Returns: true if a matching map was found, false otherwise.
+ */
+bool maps_findMapByName(const char* name, ProcessMap* out_map)
+{
+    if (!name)
+        return false;
+
+    for (uint32_t i = 0; i < maps_cache_size; i++) {
+        const char* name = maps_cache[i].name;
+        if (strstr(name, name) != NULL) {
+            *out_map = maps_cache[i];
+            return true;
+        }
+    }
+
+    // We didnt find it, get
+    maps_getAll();
+
+    for (uint32_t i = 0; i < maps_cache_size; i++) {
+        const char* name = maps_cache[i].name;
+        if (strstr(name, name) != NULL) {
+            *out_map = maps_cache[i];
+            if (!maps_cache_cycles) { // Cache is disabled, clear after use
+                maps_clearCache();
+            }
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/src/lasr/maps/maps.h
+++ b/src/lasr/maps/maps.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "src/lasr/utils.h"
+
+#define MAPS_CACHE_BLOCK_SIZE 256
+
+typedef struct MapsBlock {
+    struct MapsBlock* next;
+    size_t used;
+    ProcessMap entries[MAPS_CACHE_BLOCK_SIZE];
+} MapsBlock;
+
+extern int maps_cache_cycles;
+
+size_t maps_getAll(void);
+void maps_clearCache(void);
+bool maps_findMapByName(const char* name, ProcessMap* out_map);

--- a/src/lasr/utils.c
+++ b/src/lasr/utils.c
@@ -1,34 +1,10 @@
 #include "utils.h"
+#include "src/lasr/maps/maps.h"
 
 #include <glib.h>
 #include <stdio.h>
-#include <string.h>
 
 game_process process;
-ProcessMap p_maps_cache[MAPS_CACHE_MAX_SIZE];
-uint32_t p_maps_cache_size = 0;
-int maps_cache_cycles_value = 1; /*!< The number of cycles the cache is active for */
-
-bool parseMapsLine(const char* line, ProcessMap* map)
-{
-    uintptr_t end;
-    uint64_t size;
-    char mode[8];
-    unsigned long offset;
-    unsigned int major_id, minor_id, node_id;
-
-    // Thank you kernel source code
-    int sscanf_res = sscanf(line, "%lx-%lx %7s %lx %u:%u %u %s", &map->start,
-        &end, mode, &offset, &major_id,
-        &minor_id, &node_id, map->name);
-    if (!sscanf_res)
-        return false;
-
-    // Calculate the map size
-    size = end - map->start;
-    map->size = size;
-    return true;
-}
 
 /**
  * Gets the base address of a module.
@@ -41,38 +17,11 @@ uintptr_t find_base_address(const char* module)
 {
     const char* module_to_grep = module == 0 ? process.name : module;
 
-    for (uint32_t i = 0; i < p_maps_cache_size; i++) {
-        const char* name = p_maps_cache[i].name;
-        if (strstr(name, module_to_grep) != NULL) {
-            return p_maps_cache[i].start;
-        }
+    ProcessMap map;
+    const bool found = maps_findMapByName(module_to_grep, &map);
+    if (found) {
+        return map.start;
     }
-
-    char path[22]; // 22 is the maximum length the path can be (strlen("/proc/4294967296/maps"))
-
-    snprintf(path, sizeof(path), "/proc/%d/maps", process.pid);
-
-    FILE* f = fopen(path, "r");
-
-    if (f) {
-        char current_line[PATH_MAX + 100];
-        while (fgets(current_line, sizeof(current_line), f) != NULL) {
-            if (strstr(current_line, module_to_grep) == NULL)
-                continue;
-            fclose(f);
-            uintptr_t addr_start = strtoull(current_line, NULL, 16);
-            if (maps_cache_cycles_value != 0 && p_maps_cache_size < MAPS_CACHE_MAX_SIZE) {
-                ProcessMap map;
-                if (parseMapsLine(current_line, &map)) {
-                    p_maps_cache[p_maps_cache_size] = map;
-                    p_maps_cache_size++;
-                }
-            }
-            return addr_start;
-        }
-        fclose(f);
-    }
-    printf("Couldn't find base address\n");
     return 0;
 }
 

--- a/src/lasr/utils.h
+++ b/src/lasr/utils.h
@@ -30,16 +30,6 @@ typedef struct ProcessMap {
     char name[PATH_MAX];
 } ProcessMap;
 
-#define MAPS_CACHE_MAX_SIZE 32
-extern ProcessMap p_maps_cache[MAPS_CACHE_MAX_SIZE];
-extern uint32_t p_maps_cache_size;
-/**
- * Same as `maps_cache_cycles` but this one represents the current value
- * that changes on each cycle rather than the reference from the script
- */
-extern int maps_cache_cycles_value;
-
-bool parseMapsLine(const char* line, ProcessMap* map);
 uintptr_t find_base_address(const char* module);
 bool handle_memory_error(uint32_t err);
 const char* value_to_c_string(lua_State* L, int index);


### PR DESCRIPTION
* Now uses ioctl(PROCMAP_QUERY) to query process memory maps
* Caches maps in blocks for incremental building
* Move all maps handling into a separate folder for maps

~~This also sets the requirements to linux 6.11 which released september 2024~~ Added checks for this and kept the old version in case ioctl is not available either at compile time or runtime

Testing may be needed to check readAddress performance relative to each other on:
* [x] System that doesnt support PROCMAP_QUERY ioctl (default cache cycles)
* [x] System that doesnt support PROCMAP_QUERY ioctl (cache cycles disables)
* [x] System that supports PROCMAP_QUERY ioctl (default cache cycles)
* [x] System that supports PROCMAP_QUERY ioctl (cache cycles disabled)
(they are all somewhat the same performance as without ioctl