### PR TITLE
meson: Properly pass and fix debug flag

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,13 +1,12 @@
 project(
     'libresplit',
     'c',
-    'cpp',
-    default_options: ['c_std=gnu23', 'cpp_std=c++20'],
+    default_options: ['c_std=gnu23'],
     meson_version: '>=1.1',
 )
 
 if get_option('buildtype') == 'debug'
-    add_project_arguments('-DDEBUG', language: 'cpp')
+    add_project_arguments('-DDEBUG', language: 'c')
 endif
 
 cc = meson.get_compiler('c')

--- a/src/bind.c
+++ b/src/bind.c
@@ -558,7 +558,7 @@ void keybinder_unbind(const char* keystring, KeybinderHandler handler)
         do_ungrab_key(binding);
         bindings = g_slist_remove(bindings, binding);
 
-        TRACE(g_print("unbind, notify: %p\n", binding->notify));
+        TRACE(g_print("unbind, notify: 0x%" PRIxPTR "\n", (uintptr_t)binding->notify));
         if (binding->notify) {
             binding->notify(binding->user_data);
         }
@@ -592,7 +592,7 @@ void keybinder_unbind_all(const char* keystring)
         do_ungrab_key(binding);
         bindings = g_slist_remove(bindings, binding);
 
-        TRACE(g_print("unbind_all, notify: %p\n", binding->notify));
+        TRACE(g_print("unbind_all, notify: 0x%" PRIxPTR "\n", (uintptr_t)binding->notify));
         if (binding->notify) {
             binding->notify(binding->user_data);
         }


### PR DESCRIPTION
It was being improperly passed to cpp files, which we dont use