### PR TITLE
ci: Create appimage by installing into AppDir

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,12 +35,12 @@ jobs:
 
             - name: "Bundle extra files"
               run: |
-                  mkdir release
+                  rm -rf release
+                  mkdir -p release
+                  # Use meson install to stage the install tree for a relocatable release
+                  meson install -C build --destdir=$(pwd)/release
+                  # Include extra non-installed files
                   cp -r assets release/
-                  cp -r build/libresplit release/
-                  cp -r build/libresplit-ctl release/
-                  cp README.md release/
-                  cp LICENSE release/
 
             - name: "Upload artifacts"
               uses: actions/upload-artifact@v4
@@ -63,6 +63,7 @@ jobs:
               with:
                   pattern: LibreSplit-*
                   merge-multiple: true
+                  path: release
 
             - name: "Install AppImage dependencies"
               run: |
@@ -77,32 +78,26 @@ jobs:
               shell: bash
               run: echo "git_short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
-            - name: "Setup AppDir structure"
+            - name: "Prepare AppDir from release artifact"
               run: |
-                  mkdir -p AppDir/usr/bin
-                  mkdir -p AppDir/usr/share/applications
-                  mkdir -p AppDir/usr/share/libresplit
-                  mkdir -p AppDir/usr/share/pixmaps
-                  mkdir -p AppDir/usr/share/doc/libresplit
-                  mkdir -p AppDir/usr/share/licenses/libresplit
+                rm -rf AppDir
+                mkdir -p AppDir
 
-                  cp libresplit AppDir/usr/bin/
-                  cp libresplit-ctl AppDir/usr/bin/
-                  chmod +x AppDir/usr/bin/libresplit
-                  chmod +x AppDir/usr/bin/libresplit-ctl
+                if [ -d release ]; then
+                  cp -a release/* AppDir/
+                  rm -rf AppDir/assets
+                else
+                  echo "release directory not found; listing files:" && ls -la
+                  exit 1
+                fi
 
-                  cp assets/libresplit.desktop AppDir/usr/share/applications/
-
-                  cp assets/icons/libresplit-256.png AppDir/usr/share/pixmaps/libresplit.png
-
-                  cp LICENSE AppDir/usr/share/licenses/libresplit/
-
-                  # Create AppImage-compatible desktop entry at root
-                  cp assets/libresplit.desktop AppDir/
-                  sed -i 's/^Exec=.*/Exec=AppRun/' AppDir/libresplit.desktop
-                  cp assets/appimage.sh AppDir/AppRun
-                  chmod +x AppDir/AppRun
-                  cp assets/icons/libresplit-256.png AppDir/libresplit.png
+                mkdir -p AppDir/usr/share/applications
+                cp assets/libresplit.desktop AppDir/
+                cp assets/libresplit.desktop AppDir/usr/share/applications/
+                sed -i 's/^Exec=.*/Exec=AppRun/' AppDir/libresplit.desktop
+                cp assets/appimage.sh AppDir/AppRun
+                cp assets/icons/libresplit-256.png AppDir/libresplit.png
+                chmod +x AppDir/AppRun
 
             - name: "Download linuxdeploy"
               run: |

--- a/meson.build
+++ b/meson.build
@@ -6,10 +6,7 @@ project(
     meson_version: '>=1.1',
 )
 
-add_project_arguments(
-    '-DAPP_VERSION="@0@"'.format(meson.project_version()),
-    language: 'c'
-)
+add_project_arguments('-DAPP_VERSION="@0@"'.format(meson.project_version()), language: 'c')
 
 if get_option('buildtype') == 'debug'
     add_project_arguments('-DDEBUG', language: 'c')
@@ -130,6 +127,12 @@ foreach size : [16, 22, 24, 32, 36, 48, 64, 72, 96, 128, 256, 512, 1024]
         install_mode: 'rw-r--r--',
     )
 endforeach
+install_data(
+    'assets/libresplit.svg',
+    install_dir: get_option('prefix') / get_option('datadir') / 'icons/hicolor/scalable/apps/',
+    rename: 'libresplit.png',
+    install_mode: 'rw-r--r--',
+)
 
 gnome = import('gnome')
 #gnome.post_install(update_desktop_database: true, gtk_update_icon_cache: true)


### PR DESCRIPTION
This makes paths the same whether its an appimage or not, the only difference is the prefix