### PR TITLE
Skip linting if cppcheck is not installed

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -199,6 +199,8 @@ if cppcheck.found()
         args: cppcheck_base_args + libresplit_ctl_sources,
         suite: 'lint',
     )
+else
+    message('cppcheck not found, skipping linting test')
 endif
 
 gnome = import('gnome')


### PR DESCRIPTION
Same is done for clang-format, stops meson from exiting if the dependency is missing