### PR TITLE
settings: Use const when possible

### DIFF
--- a/src/settings/definitions.c
+++ b/src/settings/definitions.c
@@ -122,7 +122,7 @@ AppConfig cfg = {
     },
 };
 
-SectionInfo sections[] = {
+const SectionInfo sections[] = {
     { "libresplit", &cfg.libresplit, sizeof(cfg.libresplit) / sizeof(ConfigEntry), true },
     { "keybinds", &cfg.keybinds, sizeof(cfg.keybinds) / sizeof(ConfigEntry), true },
     { "history", &cfg.history, sizeof(cfg.history) / sizeof(ConfigEntry), false },

--- a/src/settings/definitions.h
+++ b/src/settings/definitions.h
@@ -18,10 +18,10 @@ typedef union ConfigValue {
 } ConfigValue;
 
 typedef struct ConfigEntry {
-    const char* key;
-    ConfigType type;
+    const char* const key;
+    const ConfigType type;
     ConfigValue value; // Serves as default value unless explicitly changed by user configuration
-    const char* desc;
+    const char* const desc;
 } ConfigEntry;
 
 typedef struct LibreSplitConfig {
@@ -62,11 +62,11 @@ typedef struct AppConfig {
  * `definitions.c` consecutively, so we can treat them as an array and
  * iterate by index to avoid repeating every field name. */
 typedef struct SectionInfo {
-    const char* name;
+    const char* const name;
     void* entries; /* pointer to first ConfigEntry in the section */
-    size_t count;
-    bool in_gui;
+    const size_t count;
+    const bool in_gui;
 } SectionInfo;
 
-extern SectionInfo sections[];
+extern const SectionInfo sections[];
 extern const size_t sections_count;

--- a/src/settings/settings.c
+++ b/src/settings/settings.c
@@ -116,7 +116,7 @@ bool config_init(void)
     }
 
     for (size_t s = 0; s < sections_count; ++s) {
-        SectionInfo* sec = &sections[s];
+        const SectionInfo* sec = &sections[s];
         json_t* sec_obj = json_object_get(root, sec->name);
         if (!sec_obj || !json_is_object(sec_obj))
             continue; // leave defaults for this section
@@ -150,7 +150,7 @@ bool config_save(void)
         return false;
 
     for (size_t s = 0; s < sections_count; ++s) {
-        SectionInfo* sec = &sections[s];
+        const SectionInfo* sec = &sections[s];
         json_t* sec_obj = json_object();
         for (size_t i = 0; i < sec->count; ++i) {
             ConfigEntry* e = (ConfigEntry*)((char*)sec->entries + (sizeof(ConfigEntry) * i));


### PR DESCRIPTION
Should still compile, and if it compiles it works since no logic changed at all
Mainly to help compiler detect constant expressions like enumerate settings and to indicate the developer what should change and what shouldnt change at runtime