### PR TITLE
maps: Add env var to disable ioctl

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,3 +13,7 @@
 
 ## Global hotkeys on wayland
 * Global hotkeys on wayland are disabled by default when the `WAYLAND_DISPLAY` environment variable is set, if you want to enable them regardless of it, you can set `LIBRESPLIT_FORCE_GLOBAL_HOTKEYS` to `1` or anything and they will be enabled, expect it to be somewhat unreliable
+
+## Memory offsets are wrong/dont work
+* This might be to some bug in fetching maps with ioctl
+* You can disable ioctl behaviour by setting `LIBRESPLIT_DISABLE_IOCTL_MAPS` environment variable to `1`.

--- a/src/lasr/maps/maps.c
+++ b/src/lasr/maps/maps.c
@@ -249,7 +249,7 @@ static size_t (*maps_getAll_var)(void) = maps_getAll_legacy;
  */
 static size_t maps_getAll_init(void)
 {
-    if (maps_ioctlSupported()) {
+    if (!getenv("LIBRESPLIT_DISABLE_IOCTL_MAPS") && maps_ioctlSupported()) {
         maps_getAll_var = maps_getAll_ioctl;
         printf("PROCMAP_QUERY is supported, using ioctl method for maps retrieval.\n");
     } else {


### PR DESCRIPTION
Basically title, just like it is done with LIBRESPLIT_FORCE_GLOBAL_HOTKEYS