### PR TITLE
Fix segfault on first start

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -985,5 +985,8 @@ int ls_timer_cancel(ls_timer* timer)
  */
 bool is_run_started(ls_timer* timer)
 {
+    if (timer == NULL) {
+        return false;
+    }
     return timer->running || atomic_load(&run_started);
 }


### PR DESCRIPTION
If no split_file key is defined in the settings file, there will be a NULL-point dereference, leading to a segfault. This fixes that.