### PR TITLE
Fix SIGSEGV on startup by handling NULL timer in is_run_started

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -985,5 +985,9 @@ int ls_timer_cancel(ls_timer* timer)
  */
 bool is_run_started(ls_timer* timer)
 {
+    if (timer == NULL) {
+        return false;
+    }
+
     return timer->running || atomic_load(&run_started);
 }


### PR DESCRIPTION
The app was crashing because is_run_started was called with a NULL timer during the activation phase. Added a NULL check to handle this gracefully.