### PR TITLE
Keygrabber for Keybinds

### DIFF
--- a/src/gui/settings_dialog.c
+++ b/src/gui/settings_dialog.c
@@ -1,16 +1,25 @@
 #include "settings_dialog.h"
-#include "gdk/gdk.h"
-#include "glibconfig.h"
 #include "src/settings/definitions.h"
 #include "src/settings/settings.h"
 
 #include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gdk/gdk.h>
 #include <glib-object.h>
+#include <glibconfig.h>
 #include <gtk/gtk.h>
 #include <stdio.h>
 
 static LSGuiSetting* gui_settings;
 
+/**
+ * Takes the application config and counts how many settings are available.
+ *
+ * This is used to create space for the dynamic settings window.
+ *
+ * @param cfg The LibreSplit AppConfig instance.
+ *
+ * @return The number of settings available.
+ */
 static size_t enumerate_settings(AppConfig cfg)
 {
     int settings_number = 0;
@@ -24,6 +33,15 @@ static size_t enumerate_settings(AppConfig cfg)
     return settings_number;
 }
 
+/**
+ * Frees memory when the help/about dialog is closed
+ *
+ * @param widget The Window itself
+ * @param event unused
+ * @param user_data unused
+ *
+ * @return True if everything went well.
+ */
 static gboolean on_help_window_delete(GtkWidget* widget, GdkEvent* event, gpointer user_data)
 {
     gtk_widget_destroy(widget);
@@ -31,16 +49,18 @@ static gboolean on_help_window_delete(GtkWidget* widget, GdkEvent* event, gpoint
     return TRUE;
 }
 
+/**
+ * Converts a combination of Modifiers and a keyval into a gsettings string for key binds.
+ *
+ * @param keyval The value of the Key pressed.
+ * @param modifiers The modifiers that are pressed.
+ * @param buffer The buffer to write the final string into.
+ * @param buffer_size The destination buffer size
+ */
 static void get_key_string(gint keyval, GdkModifierType modifiers, char* buffer, size_t buffer_size)
 {
     const char* key_name = gdk_keyval_name(gdk_keyval_to_lower(keyval));
-    const unsigned int modifier_length = 30 * 5 * sizeof(char);
-    char* str_modifiers = (char*)malloc(modifier_length);
-
-    if (str_modifiers == NULL) {
-        printf("Cannot allocate memory for keygrab");
-        return;
-    }
+    char str_modifiers[64];
 
     str_modifiers[0] = '\0';
 
@@ -61,12 +81,20 @@ static void get_key_string(gint keyval, GdkModifierType modifiers, char* buffer,
         strcat(str_modifiers, "<Hyper>");
     }
     snprintf(buffer, buffer_size, "%s%s", str_modifiers, key_name);
-    free(str_modifiers);
 }
 
+/**
+ * Handler for key press events on "Key Grabber" entries.
+ *
+ * @param widget The entry widget
+ * @param event The key pressed event
+ * @param data unused
+ *
+ * @return True if the handler terminated correctly.
+ */
 bool on_key_press(GtkWidget* widget, GdkEventKey* event, gpointer data)
 {
-    char key_buffer[50];
+    char key_buffer[128];
     get_key_string(event->keyval, event->state, key_buffer, sizeof(key_buffer));
     gtk_entry_set_text(GTK_ENTRY(widget), key_buffer);
     return TRUE;


### PR DESCRIPTION
Very useful.

Just click into a keybind entry field and press the combination. Then save.

Fixes #265