### PR TITLE
Add optional runtime deps to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ LibreSplit requires the following dependencies on your system to compile:
 - `libjansson`
 - `luajit`
 
+and also the following (optional) runtime dependencies:
+
+- `gvfs` (for web split icons)
+- `glib-networking` (for web split icons)
+
 Install the required dependencies:
 
 - Debian-based systems


### PR DESCRIPTION
Addresses an issue that Discord user Tepiloxtl was having where split icons did not load when given a web URL for some LibreSplit users, but did for others.