### PR TITLE
appimage: Fix icon search path

### DIFF
--- a/assets/appimage.sh
+++ b/assets/appimage.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export XDG_DATA_DIRS="$APPDIR/usr/share:${XDG_DATA_DIRS:-/usr/share}"
+
 if [ $# -eq 0 ]; then
     exec "$APPDIR/usr/bin/libresplit"
 else


### PR DESCRIPTION
Makes GTK also look inside APPDIR (AppImage extracted fs) for icons, fixes welcome screen and help dialog not showing in appimage

Fixes #294 