### PR TITLE
Fix possible segfault if no type is defined.

### DIFF
--- a/src/lasr/functions/readAddress.c
+++ b/src/lasr/functions/readAddress.c
@@ -98,6 +98,12 @@ char* read_memory_string(uint64_t mem_address, int buffer_size, int32_t* err)
  */
 int readAddress(lua_State* L)
 {
+    if (lua_gettop(L) == 0) {
+        // There must be at least 2 arguments: type and address
+        printf("[readAddress] Two arguments are required: type and address. Check your auto splitter code.\n");
+        lua_pushnil(L);
+        return 1;
+    }
     if (!lua_isstring(L, 1)) {
         // The "type" argument is not a string. This will bring a segfault if left alone.
         printf("[readAddress] The type to be read must be a string. Check your auto splitter code.\n");


### PR DESCRIPTION
The type of value to read is a mandatory argument, skipping directly to the address (`readAddress(0x...)`) will lead to a segfault