### PR TITLE
Correctly free welcome_box on closing

### DIFF
--- a/src/gui/welcome_box.c
+++ b/src/gui/welcome_box.c
@@ -1,4 +1,5 @@
 #include "welcome_box.h"
+#include "glib-object.h"
 #include "utils.h"
 #include <gtk/gtk.h>
 #include <stdlib.h>
@@ -36,6 +37,7 @@ LSWelcomeBox* welcome_box_new(GtkWidget* container)
     self->welcome_lbl = gtk_label_new("Welcome to LibreSplit!\nNo split is currently loaded.\nRight click this window to open a split JSON file!");
     gtk_container_add(GTK_CONTAINER(self->box), self->welcome_lbl);
     gtk_container_add(GTK_CONTAINER(container), self->box);
+    g_signal_connect(self->box, "destroy", G_CALLBACK(welcome_box_destroy), NULL);
     return self;
 }
 


### PR DESCRIPTION
I noticed that I forgot to connect the destroy callback to the actual destroy signal for the welcome box.

No biggie, but it's worth being formally correct.