### PR TITLE
Properly resize main window when loading a split file

### DIFF
--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -1,4 +1,5 @@
 #include "game.h"
+#include "gtk/gtk.h"
 #include "src/gui/component/components.h"
 #include "src/gui/theming.h"
 #include "src/settings/definitions.h"
@@ -39,9 +40,16 @@ void ls_app_window_show_game(LSAppWindow* win)
 
     // set dimensions
     if (win->game->width > 0 && win->game->height > 0) {
+        // First set the "minimum size" allowed
         gtk_widget_set_size_request(GTK_WIDGET(win),
             win->game->width,
             win->game->height);
+        // Then automatically resize the window to the
+        // preferences
+        gtk_window_resize(GTK_WINDOW(win),
+            win->game->width,
+            win->game->height);
+        // User will still be able to resize the window up, but not down
     }
 
     // set game theme (if it is set)

--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -44,8 +44,7 @@ void ls_app_window_show_game(LSAppWindow* win)
         gtk_widget_set_size_request(GTK_WIDGET(win),
             win->game->width,
             win->game->height);
-        // Then automatically resize the window to the
-        // preferences
+        // Then automatically resize the window to the preferences
         gtk_window_resize(GTK_WINDOW(win),
             win->game->width,
             win->game->height);

--- a/src/gui/game.c
+++ b/src/gui/game.c
@@ -1,8 +1,8 @@
 #include "game.h"
-#include "gtk/gtk.h"
 #include "src/gui/component/components.h"
 #include "src/gui/theming.h"
 #include "src/settings/definitions.h"
+#include <gtk/gtk.h>
 
 extern AppConfig cfg;
 


### PR DESCRIPTION
Using `gtk_widget_set_size_request` only sets the minimum size of the window, so the window can only grow in size.

Following it with a real window resize fixes the issue. The user can still resize the window manually, but only make it bigger than the values in the split file.

Fixes #332 