### PR TITLE
Make sure dialogs at least try to find a parent window

### DIFF
--- a/src/gui/dialogs.c
+++ b/src/gui/dialogs.c
@@ -5,8 +5,8 @@
  *
  * @return False, to remove the function from the queue.
  */
-#include "gio/gio.h"
 #include "src/lasr/auto-splitter.h"
+#include <gio/gio.h>
 #include <glib.h>
 #include <gtk/gtk.h>
 #include <stdatomic.h>


### PR DESCRIPTION
Given when the dialogs are viewed, the only active window should be the main window from LibreSplit. If push comes to shove, we can change the code to iterate through all windows until we find one that is "marked" as the main window.

Fixes #261