### PR TITLE
Save context menu pointer in window

### DIFF
--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -326,6 +326,7 @@ static void ls_app_window_init(LSAppWindow* win)
 
     win->display = gdk_display_get_default();
     win->style = NULL;
+    win->context_menu = NULL;
 
     // make data path
     win->data_path[0] = '\0';

--- a/src/gui/app_window.h
+++ b/src/gui/app_window.h
@@ -46,6 +46,7 @@ typedef struct _LSAppWindow {
     GtkWidget* container;
     LSWelcomeBox* welcome_box;
     GtkWidget* box;
+    GtkWidget* context_menu; /*!< The context menu */
     GList* components;
     GtkWidget* footer;
     GtkCssProvider* reset_style; /*!< The "reset rules" provider, will remove desktop theme rules */

--- a/src/gui/context_menu.c
+++ b/src/gui/context_menu.c
@@ -25,50 +25,54 @@ gboolean button_right_click(GtkWidget* widget, GdkEventButton* event, gpointer a
         } else {
             win = ls_app_window_new(LS_APP(app));
         }
-        GtkWidget* menu = gtk_menu_new();
-        GtkWidget* menu_open_splits = gtk_menu_item_new_with_label("Open Splits");
-        GtkWidget* menu_save_splits = gtk_menu_item_new_with_label("Save Splits");
-        GtkWidget* menu_open_auto_splitter = gtk_menu_item_new_with_label("Open Auto Splitter");
-        GtkWidget* menu_enable_auto_splitter = gtk_check_menu_item_new_with_label("Enable Auto Splitter");
-        gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(menu_enable_auto_splitter), atomic_load(&auto_splitter_enabled));
-        GtkWidget* menu_enable_win_on_top = gtk_check_menu_item_new_with_label("Always on Top");
-        gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(menu_enable_win_on_top), win->opts.win_on_top);
-        GtkWidget* menu_reload = gtk_menu_item_new_with_label("Reload");
-        GtkWidget* menu_close = gtk_menu_item_new_with_label("Close");
-        GtkWidget* menu_settings = gtk_menu_item_new_with_label("Settings");
-        GtkWidget* menu_about = gtk_menu_item_new_with_label("About and help");
-        GtkWidget* menu_quit = gtk_menu_item_new_with_label("Quit");
+        if (win->context_menu == NULL) {
+            GtkWidget* menu = gtk_menu_new();
+            GtkWidget* menu_open_splits = gtk_menu_item_new_with_label("Open Splits");
+            GtkWidget* menu_save_splits = gtk_menu_item_new_with_label("Save Splits");
+            GtkWidget* menu_open_auto_splitter = gtk_menu_item_new_with_label("Open Auto Splitter");
+            GtkWidget* menu_enable_auto_splitter = gtk_check_menu_item_new_with_label("Enable Auto Splitter");
+            gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(menu_enable_auto_splitter), atomic_load(&auto_splitter_enabled));
+            GtkWidget* menu_enable_win_on_top = gtk_check_menu_item_new_with_label("Always on Top");
+            gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(menu_enable_win_on_top), win->opts.win_on_top);
+            GtkWidget* menu_reload = gtk_menu_item_new_with_label("Reload");
+            GtkWidget* menu_close = gtk_menu_item_new_with_label("Close");
+            GtkWidget* menu_settings = gtk_menu_item_new_with_label("Settings");
+            GtkWidget* menu_about = gtk_menu_item_new_with_label("About and help");
+            GtkWidget* menu_quit = gtk_menu_item_new_with_label("Quit");
 
-        // Add the menu items to the menu
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_open_splits);
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_save_splits);
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_open_auto_splitter);
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_enable_auto_splitter);
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_reload);
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_close);
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_enable_win_on_top);
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_settings);
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_about);
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
-        gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_quit);
+            // Add the menu items to the menu
+            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_open_splits);
+            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_save_splits);
+            gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_open_auto_splitter);
+            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_enable_auto_splitter);
+            gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_reload);
+            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_close);
+            gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_enable_win_on_top);
+            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_settings);
+            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_about);
+            gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
+            gtk_menu_shell_append(GTK_MENU_SHELL(menu), menu_quit);
 
-        // Attach the callback functions to the menu items
-        g_signal_connect(menu_open_splits, "activate", G_CALLBACK(open_activated), app);
-        g_signal_connect(menu_save_splits, "activate", G_CALLBACK(save_activated), app);
-        g_signal_connect(menu_open_auto_splitter, "activate", G_CALLBACK(open_auto_splitter), app);
-        g_signal_connect(menu_enable_auto_splitter, "toggled", G_CALLBACK(toggle_auto_splitter), NULL);
-        g_signal_connect(menu_enable_win_on_top, "toggled", G_CALLBACK(menu_toggle_win_on_top), app);
-        g_signal_connect(menu_reload, "activate", G_CALLBACK(reload_activated), app);
-        g_signal_connect(menu_close, "activate", G_CALLBACK(close_activated), app);
-        g_signal_connect(menu_settings, "activate", G_CALLBACK(show_settings_dialog), app);
-        g_signal_connect(menu_about, "activate", G_CALLBACK(show_help_dialog), app);
-        g_signal_connect(menu_quit, "activate", G_CALLBACK(quit_activated), app);
+            // Attach the callback functions to the menu items
+            g_signal_connect(menu_open_splits, "activate", G_CALLBACK(open_activated), app);
+            g_signal_connect(menu_save_splits, "activate", G_CALLBACK(save_activated), app);
+            g_signal_connect(menu_open_auto_splitter, "activate", G_CALLBACK(open_auto_splitter), app);
+            g_signal_connect(menu_enable_auto_splitter, "toggled", G_CALLBACK(toggle_auto_splitter), NULL);
+            g_signal_connect(menu_enable_win_on_top, "toggled", G_CALLBACK(menu_toggle_win_on_top), app);
+            g_signal_connect(menu_reload, "activate", G_CALLBACK(reload_activated), app);
+            g_signal_connect(menu_close, "activate", G_CALLBACK(close_activated), app);
+            g_signal_connect(menu_settings, "activate", G_CALLBACK(show_settings_dialog), app);
+            g_signal_connect(menu_about, "activate", G_CALLBACK(show_help_dialog), app);
+            g_signal_connect(menu_quit, "activate", G_CALLBACK(quit_activated), app);
 
-        gtk_widget_show_all(menu);
-        gtk_menu_popup_at_pointer(GTK_MENU(menu), (GdkEvent*)event);
+            win->context_menu = menu;
+        }
+
+        gtk_widget_show_all(win->context_menu);
+        gtk_menu_popup_at_pointer(GTK_MENU(win->context_menu), (GdkEvent*)event);
         return TRUE;
     }
     return FALSE;


### PR DESCRIPTION
Previously the menu was regenerated and the old pointer never freed, leading to a memory leak.

Fixes #350