### PR TITLE
Fix possible crash with bad signature

### DIFF
--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -122,6 +122,11 @@ uint16_t* convert_signature(const char* signature, size_t* pattern_size)
     }
 
     char* token = strtok(signature_copy, " ");
+    if (token == NULL) {
+        // Signature is all delimiters or empty
+        free(signature_copy);
+        return NULL;
+    }
     size_t size = 0;
     size_t capacity = 10;
     uint16_t* pattern = (uint16_t*)malloc(capacity * sizeof(uint16_t));


### PR DESCRIPTION
When a signature is all spaces or an empty string, the behaviour of the signature scan is undefined.

This PR exits early in such cases.