### PR TITLE
Use "pgrep -f" when looking for PID

### DIFF
--- a/docs/auto-splitters.md
+++ b/docs/auto-splitters.md
@@ -20,7 +20,13 @@
 ```lua
 process('GameBlaBlaBla.exe')
 ```
-* With this line, LibreSplit will repeatedly attempt to find this process and will not continue script execution until it is found.
+* With this line, LibreSplit will repeatedly attempt to find this process and will not continue script execution until it is found. This is limited to 15 characters in length (the ones present in `/proc/<pid>/stat`).
+
+If you want to use longer names or check the entire command line use the `cmdline` function:
+
+```lua
+cmdline('MyGameHasAVeryLongName.exe')
+```
 
 * Next we have to define the basic functions. Not all are required and the ones that are required may change depending on the game or end goal, like if loading screens are included or not.
     * The order at which these run is the same as they are documented below.

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -101,6 +101,7 @@ static const luaL_Reg lj_lib_load[] = {
  */
 static const lasr_function luac_functions[] = {
     { "process", find_process_id },
+    { "cmdline", find_cmdline_id },
     { "getBaseAddress", getBaseAddress },
     { "readAddress", readAddress },
     { "sizeOf", size_of },

--- a/src/lasr/functions/process.c
+++ b/src/lasr/functions/process.c
@@ -90,7 +90,7 @@ int find_process_id(lua_State* L)
     }
 
     char command[256];
-    snprintf(command, sizeof(command), "pgrep \"%.*s\"%s", (int)strnlen(process.name, sizeof(command) - strlen(sortCmd) - 1), process.name, sortCmd);
+    snprintf(command, sizeof(command), "pgrep -f \"%.*s\"%s", (int)strnlen(process.name, sizeof(command) - strlen(sortCmd) - 1), process.name, sortCmd);
 
     stock_process_id(command);
 

--- a/src/lasr/functions/process.c
+++ b/src/lasr/functions/process.c
@@ -96,3 +96,45 @@ int find_process_id(lua_State* L)
 
     return 0;
 }
+
+/**
+ * Finds the ID of the process indicated by the Lua Auto Splitter using full commandline grepping.
+ *
+ *  NOTE: [Penaz] [2026-04-25] This differs from find_process_id only by the -f argument. Consider
+ *  ^ merging the command creation into a single function instead of duplicating code.
+ *
+ * @param L The Lua State.
+ *
+ * @return Always zero.
+ */
+int find_cmdline_id(lua_State* L)
+{
+    printf("\033[2J\033[1;1H"); // Clear the console
+
+    process.name = lua_tostring(L, 1);
+    const char* sort = lua_tostring(L, 2);
+    char sortCmd[16] = "";
+
+    if (!sort) {
+        sort = "first";
+    } else {
+        if (strcmp(sort, "first") != 0 && strcmp(sort, "last") != 0) {
+            printf("[process] Invalid sort argument '%s'. Use 'first' or 'last'. Falling back to first\n", sort);
+            sort = "first";
+        }
+    }
+
+    if (strcmp(sort, "first") == 0) {
+        sortCmd[0] = '\0'; // No sorting
+    }
+    if (strcmp(sort, "last") == 0) {
+        strcpy(sortCmd, " | sort -r"); // Reverse the sorting to get latest PID
+    }
+
+    char command[256];
+    snprintf(command, sizeof(command), "pgrep -f \"%.*s\"%s", (int)strnlen(process.name, sizeof(command) - strlen(sortCmd) - 1), process.name, sortCmd);
+
+    stock_process_id(command);
+
+    return 0;
+}

--- a/src/lasr/functions/process.c
+++ b/src/lasr/functions/process.c
@@ -90,7 +90,7 @@ int find_process_id(lua_State* L)
     }
 
     char command[256];
-    snprintf(command, sizeof(command), "pgrep -f \"%.*s\"%s", (int)strnlen(process.name, sizeof(command) - strlen(sortCmd) - 1), process.name, sortCmd);
+    snprintf(command, sizeof(command), "pgrep \"%.*s\"%s", (int)strnlen(process.name, sizeof(command) - strlen(sortCmd) - 1), process.name, sortCmd);
 
     stock_process_id(command);
 

--- a/src/lasr/functions/process.h
+++ b/src/lasr/functions/process.h
@@ -3,3 +3,4 @@
 #include <lua.h>
 
 int find_process_id(lua_State* L);
+int find_cmdline_id(lua_State* L);


### PR DESCRIPTION
This might give issues if multiple commands contain the searched process name (instead of the process name)

From "man pgrep":

The  process  name  used  for  matching  is  limited  to  the  15  characters  present  in  the output of /proc/pid/stat.  Use the -f option to match against the complete command line, /proc/pid/cmdline. Threads may not have the same process name as the parent process but will have the same command line.