### PR TITLE
processExists: To be used for checking multiple game versions with different process names

### DIFF
--- a/docs/auto-splitters.md
+++ b/docs/auto-splitters.md
@@ -23,10 +23,10 @@ process('GameBlaBlaBla.exe')
 
 - With this line, LibreSplit will repeatedly attempt to find this process and will not continue script execution until it is found. This is limited to 15 characters in length (the ones present in `/proc/<pid>/stat`).
 
-If you want to use longer names or check the entire command line use the `cmdline` function:
+If you want to use longer names or check the entire command line add `cmdline` on second parameter:
 
 ```lua
-cmdline('MyGameHasAVeryLongName.exe')
+process('MyGameHasAVeryLongName.exe', 'cmdline')
 ```
 
 - Next we have to define the basic functions. Not all are required and the ones that are required may change depending on the game or end goal, like if loading screens are included or not.
@@ -514,7 +514,7 @@ local array_size = sizeOf("byte25")
 
 **Warning:** As it is now, `sizeOf` returns the size in bytes. This may not be what is needed to properly work with pointers and may see some changes in the future for better integration with the rest of the Auto-Splitter Runtime.
 
-## getModuleSize
+## `getModuleSize`
 
 Given a certain module name (or nothing/nil), returns the size of the module.
 
@@ -524,7 +524,7 @@ local main_module_size_2 = getModuleSize(nil);
 local other_module_size = getModuleSize("other_module");
 ```
 
-## getMaps
+## `getMaps`
 
 Returns an array-like table that contains other tables: one for each of the process's memory maps.
 
@@ -555,7 +555,7 @@ Usage:
 local maps = getMaps()
 ```
 
-## processExists
+## `processExists`
 
 Check if a process is running without attaching to it.
 
@@ -576,4 +576,6 @@ elseif processExists(version.Remake) then
 end
 ```
 
-`processExists()` will return `true` or `false`
+`processExists()` will return `true` or `false`.
+
+_Note: If you want to use longer names, add `cmdline` on second parameter like in `process()` function._

--- a/docs/auto-splitters.md
+++ b/docs/auto-splitters.md
@@ -557,7 +557,9 @@ local maps = getMaps()
 
 ## processExists
 
-If you have multiple version of the game with different process name. You can use `processExists` function in a conditional statement to detect which game version that is running.
+Check if a process is running without attaching to it.
+
+Useful if you have multiple version of the game with different process names.
 
 For example:
 
@@ -573,3 +575,5 @@ elseif processExists(version.Remake) then
     process(version.Remake)
 end
 ```
+
+`processExists()` will return `true` or `false`

--- a/docs/auto-splitters.md
+++ b/docs/auto-splitters.md
@@ -1,26 +1,27 @@
 # Auto Splitters
 
-* Auto splitters are scripts that automate the process of timing your run in a game by making splits automatically, starting, resetting, pausing, etc.
+- Auto splitters are scripts that automate the process of timing your run in a game by making splits automatically, starting, resetting, pausing, etc.
 
 # How do they work?
 
-* These work by reading into game's memory and determining when the timer should do something, like make a split.
+- These work by reading into game's memory and determining when the timer should do something, like make a split.
 
-* LibreSplit's autosplitting system works in a very similar way to LiveSplit's. The main difference is that LibreSplit uses Lua instead of C#. There are also some key differences:
-    * Runs an entire Lua system instead of only supporting specifically named C# blocks.
-        * This means you can run external functions outside of the ones LibreSplit executes.
-    * Support for the entire Lua language, including the importing of libraries for tasks such as performance monitoring.
+- LibreSplit's autosplitting system works in a very similar way to LiveSplit's. The main difference is that LibreSplit uses Lua instead of C#. There are also some key differences:
+  - Runs an entire Lua system instead of only supporting specifically named C# blocks.
+    - This means you can run external functions outside of the ones LibreSplit executes.
+  - Support for the entire Lua language, including the importing of libraries for tasks such as performance monitoring.
 
 # How to make LibreSplit auto splitters
 
-* It's somewhat easy if you know what you are doing or are porting an already existing one.
+- It's somewhat easy if you know what you are doing or are porting an already existing one.
 
-* First in the lua script goes a `process` function call with the name of the games process:
+- First in the lua script goes a `process` function call with the name of the games process:
 
 ```lua
 process('GameBlaBlaBla.exe')
 ```
-* With this line, LibreSplit will repeatedly attempt to find this process and will not continue script execution until it is found. This is limited to 15 characters in length (the ones present in `/proc/<pid>/stat`).
+
+- With this line, LibreSplit will repeatedly attempt to find this process and will not continue script execution until it is found. This is limited to 15 characters in length (the ones present in `/proc/<pid>/stat`).
 
 If you want to use longer names or check the entire command line use the `cmdline` function:
 
@@ -28,11 +29,13 @@ If you want to use longer names or check the entire command line use the `cmdlin
 cmdline('MyGameHasAVeryLongName.exe')
 ```
 
-* Next we have to define the basic functions. Not all are required and the ones that are required may change depending on the game or end goal, like if loading screens are included or not.
-    * The order at which these run is the same as they are documented below.
+- Next we have to define the basic functions. Not all are required and the ones that are required may change depending on the game or end goal, like if loading screens are included or not.
+  - The order at which these run is the same as they are documented below.
 
 ### `startup`
- The purpose of this function is to specify how many times LibreSplit checks memory values and executes functions each second, the default is 60Hz. Usually, 60Hz is fine and this function can remain undefined. However, it's there if you need it. Its also useful to change other configuration about the script.
+
+The purpose of this function is to specify how many times LibreSplit checks memory values and executes functions each second, the default is 60Hz. Usually, 60Hz is fine and this function can remain undefined. However, it's there if you need it. Its also useful to change other configuration about the script.
+
 ```lua
 process('GameBlaBlaBla.exe')
 
@@ -43,8 +46,10 @@ end
 ```
 
 ### `state`
- The main purpose of this function is to assign memory values to Lua variables.
-* Runs every 1000 / `refreshRate` milliseconds and when the script is enabled/loaded.
+
+The main purpose of this function is to assign memory values to Lua variables.
+
+- Runs every 1000 / `refreshRate` milliseconds and when the script is enabled/loaded.
 
 ```lua
 process('GameBlaBlaBla.exe')
@@ -60,11 +65,14 @@ function state()
 end
 ```
 
-* You may have noticed that we're assigning this `isLoading` variable with the result of the function `readAddress`. This function is part of LibreSplit's Lua context and its purpose is to read memory values. It's explained in detail at the bottom of this document.
+- You may have noticed that we're assigning this `isLoading` variable with the result of the function `readAddress`. This function is part of LibreSplit's Lua context and its purpose is to read memory values. It's explained in detail at the bottom of this document.
 
 ### `update`
- The purpose of this function is to update local variables.
-* Runs every 1000 / `refreshRate` milliseconds.
+
+The purpose of this function is to update local variables.
+
+- Runs every 1000 / `refreshRate` milliseconds.
+
 ```lua
 process('GameBlaBlaBla.exe')
 
@@ -88,12 +96,16 @@ function update()
     end
 end
 ```
-* We now have 3 variables, one represents the current state while the other the old state of isLoading, we also have loadCount getting updated in the `update` function which will store how many times we've entered the loading screen
+
+- We now have 3 variables, one represents the current state while the other the old state of isLoading, we also have loadCount getting updated in the `update` function which will store how many times we've entered the loading screen
 
 ### `start`
+
 This tells LibreSplit when to start the timer.\
 _Note: LibreSplit will ignore any start calls if the timer is running._
-* Runs every 1000 / `refreshRate` milliseconds.
+
+- Runs every 1000 / `refreshRate` milliseconds.
+
 ```lua
 process('GameBlaBlaBla.exe')
 
@@ -123,8 +135,9 @@ end
 ```
 
 ### `split`
-Tells LibreSplit to execute a split whenever it gets a true return.
-    * Runs every 1000 / `refreshRate` milliseconds.
+
+Tells LibreSplit to execute a split whenever it gets a true return. \* Runs every 1000 / `refreshRate` milliseconds.
+
 ```lua
 process('GameBlaBlaBla.exe')
 
@@ -162,13 +175,17 @@ function split()
     return shouldSplit;
 end
 ```
-* Whoa lots of code, why didnt we just return if we are currently in a loading screen like in start? Because if we do, we will do multiple splits a second, the function runs multiple times and it would do lots of unwanted splits.
-* To solve that, we only want to split when we enter a loading screen (old is false, current is true), but we also don't want to split on the first loading screen as we have the assumption that the first loading screen is when the run starts. So that's where our loadCount comes in handy, we can just check if we are on the first one and only split when we aren't.
+
+- Whoa lots of code, why didnt we just return if we are currently in a loading screen like in start? Because if we do, we will do multiple splits a second, the function runs multiple times and it would do lots of unwanted splits.
+- To solve that, we only want to split when we enter a loading screen (old is false, current is true), but we also don't want to split on the first loading screen as we have the assumption that the first loading screen is when the run starts. So that's where our loadCount comes in handy, we can just check if we are on the first one and only split when we aren't.
 
 ### `isLoading`
+
 Marks the timer as "loading"/"paused". When paused, it will start adding time to LT (Loading Time), effectively pausing RTA.
 Only has an effect on RTA/LRT (Load Removed Time). Doesnt affect splitter logic at all.
-* Runs every 1000 / `refreshRate` milliseconds.
+
+- Runs every 1000 / `refreshRate` milliseconds.
+
 ```lua
 process('GameBlaBlaBla.exe')
 
@@ -212,11 +229,15 @@ function isLoading()
     return current.isLoading
 end
 ```
-* Pretty self explanatory, since we want to return whenever we are currently in a loading screen, we can just send our current isLoading status, same as start.
+
+- Pretty self explanatory, since we want to return whenever we are currently in a loading screen, we can just send our current isLoading status, same as start.
 
 # `reset`
+
 Instantly resets the timer. Use with caution.
-* Runs every 1000 / `refreshRate` milliseconds.
+
+- Runs every 1000 / `refreshRate` milliseconds.
+
 ```lua
 process('GameBlaBlaBla.exe')
 
@@ -266,13 +287,18 @@ function reset()
     return false
 end
 ```
-* In this example we are checking for the scene, of course, the address is completely arbitrary and doesnt mean anything for this example. Specifically we are checking if we are entering the MenuScene scene.
+
+- In this example we are checking for the scene, of course, the address is completely arbitrary and doesnt mean anything for this example. Specifically we are checking if we are entering the MenuScene scene.
 
 # `gameTime`
+
 ### **When using `gameTime`, `isLoading` has to ALWAYS return true**
+
 Function that is used to set the current timer time when `useGameTime` is `true` (`false` by default)
-* The return value of this function should be the current time in milliseconds
-* Runs every 1000 / `refreshRate` milliseconds.
+
+- The return value of this function should be the current time in milliseconds
+- Runs every 1000 / `refreshRate` milliseconds.
+
 ```lua
 process('GameBlaBlaBla.exe')
 
@@ -328,35 +354,35 @@ function gameTime()
     return IGT -- Assuming IGT is the current time in milliseconds tracked by the game
 end
 ```
-* In this example we added `IGT`, which is the variable in which the game keeps track of how long you've played for by some way or another, later this IGT variable is used as a return value to the `gameTime` function. Also the `useGameTime` is set to true to be able to use this feature
 
+- In this example we added `IGT`, which is the variable in which the game keeps track of how long you've played for by some way or another, later this IGT variable is used as a return value to the `gameTime` function. Also the `useGameTime` is set to true to be able to use this feature
 
 ## readAddress
-* `readAddress` is the second function that LibreSplit defines for us and its globally available, its job is to read the memory value of a specified address.
-* The first value defines what kind of value we will read:
-    1. `sbyte`: signed 8 bit integer
-    2. `byte`: unsigned 8 bit integer
-    3. `short`: signed 16 bit integer
-    4. `ushort`: unsigned 16 bit integer
-    5. `int`: signed 32 bit integer
-    6. `uint`: unsigned 32 bit integer
-    7. `long`: signed 64 bit integer
-    8. `ulong`: unsigned 64 bit integer
-    9. `float`: 32 bit floating point number
-    10. `double`: 64 bit floating point number
-    11. `bool`: Boolean (true or false)
-    12. `stringX`, A string of characters. Its usage is different compared the rest, you type "stringX" where the X is how long the string can be plus 1, this is to allocate the NULL terminator which defines when the string ends, for example, if the longest possible string to return is "cheese", you would define it as "string7". Setting X lower can result in the string terminating incorrectly and getting an incorrect result, setting it higher doesnt have any difference (aside from wasting memory).
-    13. `byteX`: An array of bytes, functions the same as `stringX`, but it reads bytes instead, the result is given in the form of an "array", also known as just a table that you can access with indexes, like `result[10]` will give you the 10th byte of whatever array you read
 
-* The second argument can be 2 things, a string or a number.
-    * If its a number: The value in that memory address of the main process will be used.
-    * If its a string: It will find the corresponding map of that string, for example "UnityPlayer.dll", This means that instead of reading the memory of the main map of the process (main binary .exe), it will instead read the memory of UnityPlayer.dll's memory space.
-        * Next you have to add another argument, this will be the offset at which to read from from the perspective of the base address of the module, meaning if the module is mapped to 0x1000 to 0xFFFF and you put 0x0100 in the offset, it will read the value in the address 0x1010.
+- `readAddress` is the second function that LibreSplit defines for us and its globally available, its job is to read the memory value of a specified address.
+- The first value defines what kind of value we will read:
+  1. `sbyte`: signed 8 bit integer
+  2. `byte`: unsigned 8 bit integer
+  3. `short`: signed 16 bit integer
+  4. `ushort`: unsigned 16 bit integer
+  5. `int`: signed 32 bit integer
+  6. `uint`: unsigned 32 bit integer
+  7. `long`: signed 64 bit integer
+  8. `ulong`: unsigned 64 bit integer
+  9. `float`: 32 bit floating point number
+  10. `double`: 64 bit floating point number
+  11. `bool`: Boolean (true or false)
+  12. `stringX`, A string of characters. Its usage is different compared the rest, you type "stringX" where the X is how long the string can be plus 1, this is to allocate the NULL terminator which defines when the string ends, for example, if the longest possible string to return is "cheese", you would define it as "string7". Setting X lower can result in the string terminating incorrectly and getting an incorrect result, setting it higher doesnt have any difference (aside from wasting memory).
+  13. `byteX`: An array of bytes, functions the same as `stringX`, but it reads bytes instead, the result is given in the form of an "array", also known as just a table that you can access with indexes, like `result[10]` will give you the 10th byte of whatever array you read
 
-* The rest of arguments are memory offsets or pointer paths.
-    * A Pointer Path is a list of Offsets + a Base Address. The auto splitter reads the value at the base address and interprets the value as yet another address. It adds the first offset to this address and reads the value of the calculated address. It does this over and over until there are no more offsets. At that point, it has found the value it was searching for. This resembles the way objects are stored in memory. Every object has a clearly defined layout where each variable has a consistent offset within the object, so you basically follow these variables from object to object.
+- The second argument can be 2 things, a string or a number.
+  - If its a number: The value in that memory address of the main process will be used.
+  - If its a string: It will find the corresponding map of that string, for example "UnityPlayer.dll", This means that instead of reading the memory of the main map of the process (main binary .exe), it will instead read the memory of UnityPlayer.dll's memory space.
+    - Next you have to add another argument, this will be the offset at which to read from from the perspective of the base address of the module, meaning if the module is mapped to 0x1000 to 0xFFFF and you put 0x0100 in the offset, it will read the value in the address 0x1010.
 
-        * Cheat Engine is a tool that allows you to easily find Addresses and Pointer Paths for those Addresses, so you don't need to debug the game to figure out the structure of the memory.
+- The rest of arguments are memory offsets or pointer paths.
+  - A Pointer Path is a list of Offsets + a Base Address. The auto splitter reads the value at the base address and interprets the value as yet another address. It adds the first offset to this address and reads the value of the calculated address. It does this over and over until there are no more offsets. At that point, it has found the value it was searching for. This resembles the way objects are stored in memory. Every object has a clearly defined layout where each variable has a consistent offset within the object, so you basically follow these variables from object to object.
+    - Cheat Engine is a tool that allows you to easily find Addresses and Pointer Paths for those Addresses, so you don't need to debug the game to figure out the structure of the memory.
 
 ## sig_scan
 
@@ -374,12 +400,13 @@ Returns:
 
 ### Notes
 
-* `sig_scan` may require LibreSplit to have advanced memory-reading permissions, check the [troubleshooting guide](./troubleshooting.md) to see how to enable it. If such permissions are not given, LibreSplit may not be able to find some signatures.
-* Lua automatically handles the conversion of hexadecimal strings to numbers, so parsing/casting it manually is not required. You can use the result of `sig_scan` directly into `readAddress`.
-* Until the address is found, `sig_scan` returns a `nil` value.
-* Signature scanning is an expensive action. So in most cases, we recommend avoiding scanning for a signature all the time, but using a variable as a "guard", this way as soon as `sig_scan` returns a valid value, the auto splitter will skip the expensive signature scanning.
+- `sig_scan` may require LibreSplit to have advanced memory-reading permissions, check the [troubleshooting guide](./troubleshooting.md) to see how to enable it. If such permissions are not given, LibreSplit may not be able to find some signatures.
+- Lua automatically handles the conversion of hexadecimal strings to numbers, so parsing/casting it manually is not required. You can use the result of `sig_scan` directly into `readAddress`.
+- Until the address is found, `sig_scan` returns a `nil` value.
+- Signature scanning is an expensive action. So in most cases, we recommend avoiding scanning for a signature all the time, but using a variable as a "guard", this way as soon as `sig_scan` returns a valid value, the auto splitter will skip the expensive signature scanning.
 
 Mini example script with the game SPRAWL:
+
 ```lua
 process('Sprawl-Win64-Shipping.exe')
 
@@ -409,25 +436,29 @@ end
 **Attention:** The `sig_scan` function will return an address that is automatically offset with the process base address, so it is ready to use with the `readAddress` function **without a module name**. Using `readAddress` with a module name is not supported and using a module name might result in wrong or out-of-process reads.
 
 ## getPID
-* Returns the current PID
+
+- Returns the current PID
 
 # Experimental stuff
+
 ## `mapsCacheCycles`
 
-* When a `readAddress` that uses a memory map the biggest bottleneck is reading every line of `/proc/pid/maps` and checking if that line is the corresponding module. This option allows you to set for how many cycles the cache of that file should be used. The cache is global so it gets reset every x number of cycles.
-    * `0`: Disabled completely
-    * `1` (default): Enabled for the current cycle
-    * `2`: Enabled for the current cycle and the next one
-    * `3`: Enabled for the current cycle and the 2 next ones
-    * You get the idea
+- When a `readAddress` that uses a memory map the biggest bottleneck is reading every line of `/proc/pid/maps` and checking if that line is the corresponding module. This option allows you to set for how many cycles the cache of that file should be used. The cache is global so it gets reset every x number of cycles.
+  - `0`: Disabled completely
+  - `1` (default): Enabled for the current cycle
+  - `2`: Enabled for the current cycle and the next one
+  - `3`: Enabled for the current cycle and the 2 next ones
+  - You get the idea
 
 ### Performance
-* Every uncached map finding takes around 1ms (depends a lot on your RAM and CPU)
-* Every cached map finding takes around 100us
 
-* Mainly useful for lots of `readAddress`-es and the game has an uncapped game state update rate, where literally every millisecond matters
+- Every uncached map finding takes around 1ms (depends a lot on your RAM and CPU)
+- Every cached map finding takes around 100us
+
+- Mainly useful for lots of `readAddress`-es and the game has an uncapped game state update rate, where literally every millisecond matters
 
 ### Example
+
 ```lua
 function startup()
     refreshRate = 60;
@@ -452,6 +483,7 @@ end
 ```
 
 ## `getBaseAddress`
+
 Returns the base address of a given Module. If called without arguments, or with the only accepted argument as `nil`, it will return the base address of the main module.
 
 This can be useful for manual pointer manipulation, if required by the auto splitter.
@@ -468,6 +500,7 @@ local module_base_address = getbaseaddress("UnityPlayer.dll")
 ```
 
 ## `sizeOf`
+
 Returns the size of a given type. Uses the same type names as [readAddress](#readAddress) and will automatically size arrays and strings according to their length too.
 
 ```
@@ -490,6 +523,7 @@ local main_module_size = getModuleSize();
 local main_module_size_2 = getModuleSize(nil);
 local other_module_size = getModuleSize("other_module");
 ```
+
 ## getMaps
 
 Returns an array-like table that contains other tables: one for each of the process's memory maps.
@@ -519,4 +553,23 @@ Usage:
 
 ```lua
 local maps = getMaps()
+```
+
+## processExists
+
+If you have multiple version of the game with different process name. You can use `processExists` function in a conditional statement to detect which game version that is running.
+
+For example:
+
+```lua
+local version = {
+    OG = "game.exe",
+    Remake = "remake.exe"
+}
+
+if processExists(version.OG) then
+    process(version.OG)
+elseif processExists(version.Remake) then
+    process(version.Remake)
+end
 ```

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -101,7 +101,6 @@ static const luaL_Reg lj_lib_load[] = {
  */
 static const lasr_function luac_functions[] = {
     { "process", find_process_id },
-    { "cmdline", find_cmdline_id },
     { "getBaseAddress", getBaseAddress },
     { "readAddress", readAddress },
     { "sizeOf", size_of },

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -118,6 +118,7 @@ static const lasr_function luac_functions[] = {
     { "b_rshift", b_rshift },
     { "getMaps", getMaps },
     { "str2ida", str2ida },
+    { "processExists", check_process_id },
     { NULL, NULL }
 };
 

--- a/src/lasr/functions/process.c
+++ b/src/lasr/functions/process.c
@@ -77,12 +77,11 @@ int find_process_id(lua_State* L)
 
     process.name = lua_tostring(L, 1);
 
-    const char* cmdLineFlag = NULL;
+    int useCmdLine = 0;
 
-    if (lua_isstring(L, 2)) {
-        cmdLineFlag = lua_tostring(L, 2);
+    if (lua_isboolean(L, 2)) {
+        useCmdLine = lua_toboolean(L, 2);
     }
-    int useCmdLine = cmdLineFlag && strcmp(cmdLineFlag, "cmdline") == 0;
 
     const char* sort = lua_tostring(L, 3);
     char sortCmd[16] = "";
@@ -130,12 +129,11 @@ int check_process_id(lua_State* L)
                                 //
     const char* name = lua_tostring(L, 1);
 
-    const char* cmdLineFlag = NULL;
+    int useCmdLine = 0;
 
-    if (lua_isstring(L, 2)) {
-        cmdLineFlag = lua_tostring(L, 2);
+    if (lua_isboolean(L, 2)) {
+        useCmdLine = lua_toboolean(L, 2);
     }
-    int useCmdLine = cmdLineFlag && strcmp(cmdLineFlag, "cmdline") == 0;
 
     const char* sort = lua_tostring(L, 3);
     char sortCmd[16] = "";

--- a/src/lasr/functions/process.c
+++ b/src/lasr/functions/process.c
@@ -138,3 +138,49 @@ int find_cmdline_id(lua_State* L)
 
     return 0;
 }
+
+/**
+ * Checks the ID of the process indicated by the Lua Auto Splitter is running without attaching to it.
+ * Used for making conditional statement when there is multiple game versions with different process ID.
+ *
+ * @param L The Lua State.
+ *
+ * @return is 1, returning a boolean value. True if process ID was found and false the otherwise.
+ */
+int check_process_id(lua_State* L)
+{
+    printf("\033[2J\033[1;1H"); // Clear the console
+                                //
+    const char* name = lua_tostring(L, 1);
+    const char* sort = lua_tostring(L, 2);
+    char sortCmd[16] = "";
+
+    char pid_output[PATH_MAX + 100];
+    pid_output[0] = '\0';
+
+    if (!sort) {
+        sort = "first";
+    } else {
+        if (strcmp(sort, "first") != 0 && strcmp(sort, "last") != 0) {
+            printf("[process] Invalid sort argument '%s'. Use 'first' or 'last'. Falling back to first\n", sort);
+            sort = "first";
+        }
+    }
+
+    if (strcmp(sort, "first") == 0) {
+        sortCmd[0] = '\0';
+    }
+    if (strcmp(sort, "last") == 0) {
+        strcpy(sortCmd, " | sort -r");
+    }
+
+    char command[256];
+    snprintf(command, sizeof(command), "pgrep \"%.*s\"%s", (int)strnlen(name, sizeof(command) - strlen(sortCmd) - 1), name, sortCmd);
+
+    if (atomic_load(&auto_splitter_enabled)) {
+        execute_command(command, pid_output);
+    }
+    unsigned long pid = strtoul(pid_output, NULL, 10);
+    lua_pushboolean(L, pid != 0);
+    return 1;
+}

--- a/src/lasr/functions/process.c
+++ b/src/lasr/functions/process.c
@@ -1,6 +1,7 @@
 #include "process.h"
 
 #include "../utils.h"
+#include "lua.h"
 
 #include <stdatomic.h>
 #include <stdio.h>
@@ -62,6 +63,11 @@ void stock_process_id(const char* pid_command)
  * Finds the ID of the process indicated by the Lua Auto Splitter.
  *
  * @param L The Lua State.
+ * @param 1 The name of process to find.
+ * @param 2 (optional) Force using full commandline grepping, pgrep -f.
+ * @param 3 (optional) Sorting PID.
+ *
+ * Note: [AL] [2026-5-3] The sorting isn't documented or explained the use case. I'll leave it as it was before.
  *
  * @return Always zero.
  */
@@ -70,7 +76,15 @@ int find_process_id(lua_State* L)
     printf("\033[2J\033[1;1H"); // Clear the console
 
     process.name = lua_tostring(L, 1);
-    const char* sort = lua_tostring(L, 2);
+
+    const char* cmdLineFlag = NULL;
+
+    if (lua_isstring(L, 2)) {
+        cmdLineFlag = lua_tostring(L, 2);
+    }
+    int forceUseCmdLine = cmdLineFlag && strcmp(cmdLineFlag, "cmdline") == 0;
+
+    const char* sort = lua_tostring(L, 3);
     char sortCmd[16] = "";
 
     if (!sort) {
@@ -84,56 +98,16 @@ int find_process_id(lua_State* L)
 
     if (strcmp(sort, "first") == 0) {
         sortCmd[0] = '\0'; // No sorting
-    }
-    if (strcmp(sort, "last") == 0) {
+    } else if (strcmp(sort, "last") == 0) {
         strcpy(sortCmd, " | sort -r"); // Reverse the sorting to get latest PID
     }
 
     char command[256];
-    snprintf(command, sizeof(command), "pgrep \"%.*s\"%s", (int)strnlen(process.name, sizeof(command) - strlen(sortCmd) - 1), process.name, sortCmd);
-
-    stock_process_id(command);
-
-    return 0;
-}
-
-/**
- * Finds the ID of the process indicated by the Lua Auto Splitter using full commandline grepping.
- *
- *  NOTE: [Penaz] [2026-04-25] This differs from find_process_id only by the -f argument. Consider
- *  ^ merging the command creation into a single function instead of duplicating code.
- *
- * @param L The Lua State.
- *
- * @return Always zero.
- */
-int find_cmdline_id(lua_State* L)
-{
-    printf("\033[2J\033[1;1H"); // Clear the console
-
-    process.name = lua_tostring(L, 1);
-    const char* sort = lua_tostring(L, 2);
-    char sortCmd[16] = "";
-
-    if (!sort) {
-        sort = "first";
+    if (forceUseCmdLine || strlen(process.name) > 15) {
+        snprintf(command, sizeof(command), "pgrep -f \"%.*s\"%s", (int)strnlen(process.name, sizeof(command) - strlen(sortCmd) - 1), process.name, sortCmd);
     } else {
-        if (strcmp(sort, "first") != 0 && strcmp(sort, "last") != 0) {
-            printf("[process] Invalid sort argument '%s'. Use 'first' or 'last'. Falling back to first\n", sort);
-            sort = "first";
-        }
+        snprintf(command, sizeof(command), "pgrep \"%.*s\"%s", (int)strnlen(process.name, sizeof(command) - strlen(sortCmd) - 1), process.name, sortCmd);
     }
-
-    if (strcmp(sort, "first") == 0) {
-        sortCmd[0] = '\0'; // No sorting
-    }
-    if (strcmp(sort, "last") == 0) {
-        strcpy(sortCmd, " | sort -r"); // Reverse the sorting to get latest PID
-    }
-
-    char command[256];
-    snprintf(command, sizeof(command), "pgrep -f \"%.*s\"%s", (int)strnlen(process.name, sizeof(command) - strlen(sortCmd) - 1), process.name, sortCmd);
-
     stock_process_id(command);
 
     return 0;
@@ -144,6 +118,9 @@ int find_cmdline_id(lua_State* L)
  * Used for making conditional statement when there is multiple game versions with different process ID.
  *
  * @param L The Lua State.
+ * @param 1 The name of process to find.
+ * @param 2 (optional) Force using full commandline grepping, pgrep -f.
+ * @param 3 (optional) Sorting PID.
  *
  * @return is 1, returning a boolean value. True if process ID was found and false the otherwise.
  */
@@ -152,7 +129,15 @@ int check_process_id(lua_State* L)
     printf("\033[2J\033[1;1H"); // Clear the console
                                 //
     const char* name = lua_tostring(L, 1);
-    const char* sort = lua_tostring(L, 2);
+
+    const char* cmdLineFlag = NULL;
+
+    if (lua_isstring(L, 2)) {
+        cmdLineFlag = lua_tostring(L, 2);
+    }
+    int forceUseCmdLine = cmdLineFlag && strcmp(cmdLineFlag, "cmdline") == 0;
+
+    const char* sort = lua_tostring(L, 3);
     char sortCmd[16] = "";
 
     char pid_output[PATH_MAX + 100];
@@ -169,18 +154,22 @@ int check_process_id(lua_State* L)
 
     if (strcmp(sort, "first") == 0) {
         sortCmd[0] = '\0';
-    }
-    if (strcmp(sort, "last") == 0) {
+    } else if (strcmp(sort, "last") == 0) {
         strcpy(sortCmd, " | sort -r");
     }
 
     char command[256];
-    snprintf(command, sizeof(command), "pgrep \"%.*s\"%s", (int)strnlen(name, sizeof(command) - strlen(sortCmd) - 1), name, sortCmd);
+    if (forceUseCmdLine || strlen(name) > 15) {
+        snprintf(command, sizeof(command), "pgrep -f \"%.*s\"%s", (int)strnlen(name, sizeof(command) - strlen(sortCmd) - 1), name, sortCmd);
+    } else {
+        snprintf(command, sizeof(command), "pgrep \"%.*s\"%s", (int)strnlen(name, sizeof(command) - strlen(sortCmd) - 1), name, sortCmd);
+    }
 
     if (atomic_load(&auto_splitter_enabled)) {
         execute_command(command, pid_output);
     }
     unsigned long pid = strtoul(pid_output, NULL, 10);
+
     lua_pushboolean(L, pid != 0);
     return 1;
 }

--- a/src/lasr/functions/process.c
+++ b/src/lasr/functions/process.c
@@ -64,7 +64,7 @@ void stock_process_id(const char* pid_command)
  *
  * @param L The Lua State.
  * @param 1 The name of process to find.
- * @param 2 (optional) Force using full commandline grepping, pgrep -f.
+ * @param 2 (optional) Using full commandline grepping, pgrep -f.
  * @param 3 (optional) Sorting PID.
  *
  * Note: [AL] [2026-5-3] The sorting isn't documented or explained the use case. I'll leave it as it was before.
@@ -82,7 +82,7 @@ int find_process_id(lua_State* L)
     if (lua_isstring(L, 2)) {
         cmdLineFlag = lua_tostring(L, 2);
     }
-    int forceUseCmdLine = cmdLineFlag && strcmp(cmdLineFlag, "cmdline") == 0;
+    int useCmdLine = cmdLineFlag && strcmp(cmdLineFlag, "cmdline") == 0;
 
     const char* sort = lua_tostring(L, 3);
     char sortCmd[16] = "";
@@ -103,7 +103,7 @@ int find_process_id(lua_State* L)
     }
 
     char command[256];
-    if (forceUseCmdLine || strlen(process.name) > 15) {
+    if (useCmdLine) {
         snprintf(command, sizeof(command), "pgrep -f \"%.*s\"%s", (int)strnlen(process.name, sizeof(command) - strlen(sortCmd) - 1), process.name, sortCmd);
     } else {
         snprintf(command, sizeof(command), "pgrep \"%.*s\"%s", (int)strnlen(process.name, sizeof(command) - strlen(sortCmd) - 1), process.name, sortCmd);
@@ -119,7 +119,7 @@ int find_process_id(lua_State* L)
  *
  * @param L The Lua State.
  * @param 1 The name of process to find.
- * @param 2 (optional) Force using full commandline grepping, pgrep -f.
+ * @param 2 (optional) Using full commandline grepping, pgrep -f.
  * @param 3 (optional) Sorting PID.
  *
  * @return is 1, returning a boolean value. True if process ID was found and false the otherwise.
@@ -135,7 +135,7 @@ int check_process_id(lua_State* L)
     if (lua_isstring(L, 2)) {
         cmdLineFlag = lua_tostring(L, 2);
     }
-    int forceUseCmdLine = cmdLineFlag && strcmp(cmdLineFlag, "cmdline") == 0;
+    int useCmdLine = cmdLineFlag && strcmp(cmdLineFlag, "cmdline") == 0;
 
     const char* sort = lua_tostring(L, 3);
     char sortCmd[16] = "";
@@ -159,7 +159,7 @@ int check_process_id(lua_State* L)
     }
 
     char command[256];
-    if (forceUseCmdLine || strlen(name) > 15) {
+    if (useCmdLine) {
         snprintf(command, sizeof(command), "pgrep -f \"%.*s\"%s", (int)strnlen(name, sizeof(command) - strlen(sortCmd) - 1), name, sortCmd);
     } else {
         snprintf(command, sizeof(command), "pgrep \"%.*s\"%s", (int)strnlen(name, sizeof(command) - strlen(sortCmd) - 1), name, sortCmd);

--- a/src/lasr/functions/process.h
+++ b/src/lasr/functions/process.h
@@ -3,5 +3,4 @@
 #include <lua.h>
 
 int find_process_id(lua_State* L);
-int find_cmdline_id(lua_State* L);
 int check_process_id(lua_State* L);

--- a/src/lasr/functions/process.h
+++ b/src/lasr/functions/process.h
@@ -4,3 +4,4 @@
 
 int find_process_id(lua_State* L);
 int find_cmdline_id(lua_State* L);
+int check_process_id(lua_State* L);


### PR DESCRIPTION
Since we don't have feature to handle multiple different process names in autosplitter yet, like in ASL. This function can be used to workaround that.

The codes is similar to `process()` and `cmdline()`.

Need to be checked if this can cause performance issue or not.