### PR TITLE
feat: rework the autosplitter runtime lifecycle, add init/exit runtime functions

### DIFF
--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -668,8 +668,7 @@ void run_auto_splitter(void)
         }
     }
 
-    lua_pushboolean(L, 0);
-    lua_setglobal(L, "process_connected");
+    set_process_connected_global(L, 0);
     clear_process_binding();
     lua_close(L);
 }

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -668,6 +668,7 @@ void run_auto_splitter(void)
         }
     }
 
+    process_lookup_configured = false;
     set_process_connected_global(L, false);
     clear_process_binding();
     lua_close(L);

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -123,7 +123,7 @@ static const lasr_function luac_functions[] = {
 };
 
 /**
- * Clears the connection to the current process.
+ * Clears the connection to the current process by resetting the PID and base addresses, and clearing the maps cache so the next attach doesn't use an old cache by accident.
  */
 static void clear_process_binding(void)
 {
@@ -133,6 +133,11 @@ static void clear_process_binding(void)
     maps_clearCache();
 }
 
+/**
+ * Rebinds process state after an attach or re-attach.
+ *
+ * Verifies the current PID is alive, refreshes the main module and DLL base addresses for the current process and clears map caches. 
+ */
 static bool bind_process_state(void)
 {
     if (process.pid == 0 || !process_exists()) {

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -136,7 +136,7 @@ static void clear_process_binding(void)
 /**
  * Rebinds process state after an attach or re-attach.
  *
- * Verifies the current PID is alive, refreshes the main module and DLL base addresses for the current process and clears map caches. 
+ * Verifies the current PID is alive, refreshes the main module and DLL base addresses for the current process and clears map caches.
  */
 static bool bind_process_state(void)
 {

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -668,7 +668,7 @@ void run_auto_splitter(void)
         }
     }
 
-    set_process_connected_global(L, 0);
+    set_process_connected_global(L, false);
     clear_process_binding();
     lua_close(L);
 }

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -586,9 +586,9 @@ void run_auto_splitter(void)
         struct timespec clock_start;
         clock_gettime(CLOCK_MONOTONIC, &clock_start);
 
+        // TODO figure out a way to avoid spinning in a loop of creating the lua rutime and tearing it down for autosplitters without a properly configured process lookup
         if (!process_lookup_configured) {
             fprintf(stderr, "Autosplitter didn't call process() or cmdline()\n");
-            atomic_store(&auto_splitter_enabled, false);
             break;
         }
 

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -12,6 +12,7 @@
 #include <lua.h>
 #include <lualib.h>
 #include <signal.h>
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -120,6 +121,44 @@ static const lasr_function luac_functions[] = {
     { "str2ida", str2ida },
     { NULL, NULL }
 };
+
+/**
+ * Clears the connection to the current process.
+ */
+static void clear_process_binding(void)
+{
+    process.pid = 0;
+    process.base_address = 0;
+    process.dll_address = 0;
+    maps_clearCache();
+}
+
+static bool bind_process_state(void)
+{
+    if (process.pid == 0 || !process_exists()) {
+        return false;
+    }
+
+    process.base_address = find_base_address(NULL);
+    process.dll_address = process.base_address;
+
+    if (process.base_address == 0 && !process_exists()) {
+        clear_process_binding();
+        return false;
+    }
+
+    maps_clearCache();
+    return true;
+}
+
+/*
+ * Helper function to set the Lua process_connected variable's value.
+ */
+static void set_process_connected_global(lua_State* L, bool connected)
+{
+    lua_pushboolean(L, connected);
+    lua_setglobal(L, "process_connected");
+}
 
 /**
  * Registers the Lua Auto Split Runtime functions.
@@ -336,6 +375,30 @@ void state(lua_State* L)
 }
 
 /**
+ * The init() LASR function.
+ *
+ * Executes the code in the init() function of the auto splitter.
+ *
+ * @param L The Lua State
+ */
+void init(lua_State* L)
+{
+    call_va(L, "init", "");
+}
+
+/**
+ * The exit() LASR function.
+ *
+ * Executes the code in the exit() function of the auto splitter.
+ *
+ * @param L The Lua State
+ */
+void lasr_exit(lua_State* L)
+{
+    call_va(L, "exit", "");
+}
+
+/**
  * The update() LASR function.
  *
  * Executes the code in the update() function of the auto splitter.
@@ -450,6 +513,8 @@ void gameTime(lua_State* L)
  */
 void run_auto_splitter(void)
 {
+    bool connected = process.pid != 0 && process_exists();
+
     lua_State* L = luaL_newstate();
     luaL_openlibs(L);
     disable_functions(L, disabled_functions);
@@ -480,87 +545,113 @@ void run_auto_splitter(void)
         return;
     }
 
-    lua_getglobal(L, "state");
-    bool state_exists = lua_isfunction(L, -1);
-    lua_pop(L, 1); // Remove 'state' from the stack
+    bool state_exists = has_lua_function(L, "state");
+    bool start_exists = has_lua_function(L, "start");
+    bool split_exists = has_lua_function(L, "split");
+    bool is_loading_exists = has_lua_function(L, "isLoading");
+    bool startup_exists = has_lua_function(L, "startup");
+    bool reset_exists = has_lua_function(L, "reset");
+    bool update_exists = has_lua_function(L, "update");
+    bool gameTime_exists = has_lua_function(L, "gameTime");
+    bool exit_exists = has_lua_function(L, "exit");
+    bool init_exists = has_lua_function(L, "init");
 
-    lua_getglobal(L, "start");
-    bool start_exists = lua_isfunction(L, -1);
-    lua_pop(L, 1); // Remove 'start' from the stack
-
-    lua_getglobal(L, "split");
-    bool split_exists = lua_isfunction(L, -1);
-    lua_pop(L, 1); // Remove 'split' from the stack
-
-    lua_getglobal(L, "isLoading");
-    bool is_loading_exists = lua_isfunction(L, -1);
-    lua_pop(L, 1); // Remove 'isLoading' from the stack
-
-    lua_getglobal(L, "startup");
-    bool startup_exists = lua_isfunction(L, -1);
-    lua_pop(L, 1); // Remove 'startup' from the stack
-
-    lua_getglobal(L, "reset");
-    bool reset_exists = lua_isfunction(L, -1);
-    lua_pop(L, 1); // Remove 'reset' from the stack
-
-    lua_getglobal(L, "update");
-    bool update_exists = lua_isfunction(L, -1);
-    lua_pop(L, 1); // Remove 'update' from the stack
-
-    lua_getglobal(L, "gameTime");
-    bool gameTime_exists = lua_isfunction(L, -1);
-    lua_pop(L, 1); // Remove 'gameTime' from the stack
+    set_process_connected_global(L, connected);
 
     if (startup_exists) {
         startup(L);
     }
 
+    if (connected) {
+        if (!bind_process_state()) {
+            connected = false;
+            set_process_connected_global(L, false);
+        } else {
+            set_process_connected_global(L, true);
+            if (init_exists) {
+                init(L);
+            }
+        }
+    }
+
     printf("Refresh rate: %d\n", refresh_rate);
     int rate = 1000000 / refresh_rate;
 
-    while (1) {
+    while (!runtime_should_stop(current_file)) {
         struct timespec clock_start;
         clock_gettime(CLOCK_MONOTONIC, &clock_start);
 
-        if (!atomic_load(&auto_splitter_enabled) || strcmp(current_file, auto_splitter_file) != 0 || !process_exists() || process.pid == 0) {
+        if (!process_lookup_configured) {
+            fprintf(stderr, "Autosplitter didn't call process() or cmdline()\n");
+            atomic_store(&auto_splitter_enabled, false);
             break;
         }
 
-        if (state_exists) {
-            state(L);
+        bool process_available = connected ? (process.pid != 0 && process_exists()) : try_find_process(&process_lookup);
+
+        if (!connected && process_available) {
+            if (bind_process_state()) {
+                connected = true;
+                set_process_connected_global(L, true);
+
+                if (init_exists) {
+                    init(L);
+                }
+            }
+        } else if (connected && !process_available) {
+            if (exit_exists) {
+                lasr_exit(L);
+            }
+
+            connected = false;
+            set_process_connected_global(L, false);
+            clear_process_binding();
         }
 
-        if (update_exists) {
-            update(L);
-        }
+        if (connected) {
+            if (state_exists) {
+                state(L);
+            }
 
-        if (gameTime_exists && use_game_time && atomic_load(&run_started) && atomic_load(&run_running)) {
-            gameTime(L);
-        }
+            if (update_exists) {
+                update(L);
+            }
 
-        if (start_exists && !atomic_load(&run_started) && !atomic_load(&run_running)) {
-            start(L);
-        }
+            if (gameTime_exists && use_game_time && atomic_load(&run_started) && atomic_load(&run_running)) {
+                gameTime(L);
+            }
 
-        if (split_exists && atomic_load(&run_started)) {
-            split(L);
-        }
+            if (start_exists && !atomic_load(&run_started) && !atomic_load(&run_running)) {
+                start(L);
+            }
 
-        if (is_loading_exists) {
-            is_loading(L);
-        }
+            if (split_exists && atomic_load(&run_started)) {
+                split(L);
+            }
 
-        if (reset_exists && atomic_load(&run_running)) {
-            reset(L);
-        }
+            if (is_loading_exists) {
+                is_loading(L);
+            }
 
-        // Clear the memory maps cache if needed
-        maps_cache_cycles_value--;
-        if (maps_cache_cycles_value < 1) {
-            maps_clearCache();
-            maps_cache_cycles_value = maps_cache_cycles;
-            // printf("Cleared maps cache\n");
+            if (reset_exists && atomic_load(&run_running)) {
+                reset(L);
+            }
+
+            // Clear the memory maps cache if needed
+            maps_cache_cycles_value--;
+            if (maps_cache_cycles_value < 1) {
+                maps_clearCache();
+                maps_cache_cycles_value = maps_cache_cycles;
+                // printf("Cleared maps cache\n");
+            }
+        } else {
+            if (update_exists) {
+                update(L);
+            }
+
+            if (is_loading_exists) {
+                is_loading(L);
+            }
         }
 
         struct timespec clock_end;
@@ -572,5 +663,8 @@ void run_auto_splitter(void)
         }
     }
 
+    lua_pushboolean(L, 0);
+    lua_setglobal(L, "process_connected");
+    clear_process_binding();
     lua_close(L);
 }

--- a/src/lasr/functions/getBaseAddress.c
+++ b/src/lasr/functions/getBaseAddress.c
@@ -2,6 +2,7 @@
 
 #include "../maps/maps.h"
 #include "../utils.h"
+#include "lua.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -16,6 +17,11 @@
  */
 int getBaseAddress(lua_State* L)
 {
+    if (!process_is_attached()) {
+        lua_pushnil(L);
+        return 1;
+    }
+
     char module_name[PATH_MAX];
 
     if (lua_gettop(L) == 0 || lua_isnil(L, 1)) {

--- a/src/lasr/functions/getMaps.c
+++ b/src/lasr/functions/getMaps.c
@@ -1,6 +1,8 @@
 #include "getMaps.h"
 
 #include "../maps/maps.h"
+#include "../utils.h"
+#include "lua.h"
 
 #include <stdio.h>
 
@@ -11,6 +13,11 @@
  */
 int getMaps(lua_State* L)
 {
+    if (!process_is_attached()) {
+        lua_pushnil(L);
+        return 1;
+    }
+
     if (lua_gettop(L) != 0) {
         printf("[getMaps] No arguments accepted");
         lua_pushnil(L);

--- a/src/lasr/functions/getModuleSize.c
+++ b/src/lasr/functions/getModuleSize.c
@@ -1,6 +1,7 @@
 #include "getModuleSize.h"
 
 #include "../utils.h"
+#include "lua.h"
 #include "src/lasr/maps/maps.h"
 
 #include <stdint.h>
@@ -17,6 +18,11 @@
  */
 int getModuleSize(lua_State* L)
 {
+    if (!process_is_attached()) {
+        lua_pushnil(L);
+        return 1;
+    }
+
     char module_name[PATH_MAX];
 
     if (lua_gettop(L) == 0 || lua_isnil(L, 1)) {

--- a/src/lasr/functions/process.c
+++ b/src/lasr/functions/process.c
@@ -132,11 +132,14 @@ void stock_process_id(const char* pid_command)
  */
 int find_process_id(lua_State* L)
 {
-    printf("\033[2J\033[1;1H");
+    printf("\033[2J\033[1;1H"); // Clean the console
+
     process_lookup.kind = PROCESS_LOOKUP_NAME;
     strncpy(process_lookup.name, lua_tostring(L, 1), sizeof(process_lookup.name) - 1);
+
     process_lookup.name[sizeof(process_lookup.name) - 1] = '\0';
     strncpy(process_lookup.sort, normalize_sort(lua_tostring(L, 2)), sizeof(process_lookup.sort) - 1);
+
     process_lookup.sort[sizeof(process_lookup.sort) - 1] = '\0';
     process_lookup_configured = true;
     process.name = process_lookup.name;

--- a/src/lasr/functions/process.c
+++ b/src/lasr/functions/process.c
@@ -1,5 +1,6 @@
 #include "process.h"
 
+#include "../auto-splitter.h"
 #include "../utils.h"
 
 #include <stdatomic.h>
@@ -9,6 +10,37 @@
 #include <unistd.h>
 
 extern atomic_bool auto_splitter_enabled; /*!< Defines if the auto splitter is enabled */
+
+static const char* normalize_sort(const char* sort)
+{
+    if (!sort) {
+        return "first";
+    }
+
+    if (strcmp(sort, "first") != 0 && strcmp(sort, "last") != 0) {
+        printf("[process] Invalid sort argument '%s'. Use 'first' or 'last'. Falling back to first\n", sort);
+        return "first";
+    }
+
+    return sort;
+}
+
+static void build_process_command(const process_query* query, char* command, size_t command_size)
+{
+    char sortCmd[16] = "";
+    if (strcmp(query->sort, "last") == 0) {
+        strcpy(sortCmd, " | sort -r");
+    }
+    if (query->kind == PROCESS_LOOKUP_CMDLINE) {
+        snprintf(command, command_size, "pgrep -f \"%.*s\"%s",
+            (int)strnlen(query->name, command_size - strlen(sortCmd) - 1),
+            query->name, sortCmd);
+    } else {
+        snprintf(command, command_size, "pgrep \"%.*s\"%s",
+            (int)strnlen(query->name, command_size - strlen(sortCmd) - 1),
+            query->name, sortCmd);
+    }
+}
 
 /**
  * Executes a command, piping its output into an output string.
@@ -30,6 +62,39 @@ void execute_command(const char* command, char* output)
     }
 
     pclose(pipe);
+}
+
+bool try_find_process(const process_query* query)
+{
+    char pid_output[PATH_MAX + 100];
+    char command[256];
+    pid_output[0] = '\0';
+    build_process_command(query, command, sizeof(command));
+    execute_command(command, pid_output);
+    process.pid = strtoul(pid_output, NULL, 10);
+    if (!process.pid) {
+        return false;
+    }
+    size_t newlinePos = strcspn(pid_output, "\n");
+    if (newlinePos != strlen(pid_output) - 1 && pid_output[0] != '\0') {
+        printf("Multiple PID's found for process: %s\n", query->name);
+    }
+    process.name = process_lookup.name;
+    printf("Process: %s\n", process.name);
+    printf("PID: %u\n", process.pid);
+    return true;
+}
+
+bool wait_for_process(const process_query* query, const char* current_file)
+{
+    while (!runtime_should_stop(current_file)) {
+        if (try_find_process(query)) {
+            return true;
+        }
+        printf("%s isn't running.\n", query->name);
+        usleep(100000);
+    }
+    return false;
 }
 
 void stock_process_id(const char* pid_command)
@@ -67,33 +132,15 @@ void stock_process_id(const char* pid_command)
  */
 int find_process_id(lua_State* L)
 {
-    printf("\033[2J\033[1;1H"); // Clear the console
-
-    process.name = lua_tostring(L, 1);
-    const char* sort = lua_tostring(L, 2);
-    char sortCmd[16] = "";
-
-    if (!sort) {
-        sort = "first";
-    } else {
-        if (strcmp(sort, "first") != 0 && strcmp(sort, "last") != 0) {
-            printf("[process] Invalid sort argument '%s'. Use 'first' or 'last'. Falling back to first\n", sort);
-            sort = "first";
-        }
-    }
-
-    if (strcmp(sort, "first") == 0) {
-        sortCmd[0] = '\0'; // No sorting
-    }
-    if (strcmp(sort, "last") == 0) {
-        strcpy(sortCmd, " | sort -r"); // Reverse the sorting to get latest PID
-    }
-
-    char command[256];
-    snprintf(command, sizeof(command), "pgrep \"%.*s\"%s", (int)strnlen(process.name, sizeof(command) - strlen(sortCmd) - 1), process.name, sortCmd);
-
-    stock_process_id(command);
-
+    printf("\033[2J\033[1;1H");
+    process_lookup.kind = PROCESS_LOOKUP_NAME;
+    strncpy(process_lookup.name, lua_tostring(L, 1), sizeof(process_lookup.name) - 1);
+    process_lookup.name[sizeof(process_lookup.name) - 1] = '\0';
+    strncpy(process_lookup.sort, normalize_sort(lua_tostring(L, 2)), sizeof(process_lookup.sort) - 1);
+    process_lookup.sort[sizeof(process_lookup.sort) - 1] = '\0';
+    process_lookup_configured = true;
+    process.name = process_lookup.name;
+    wait_for_process(&process_lookup, auto_splitter_file);
     return 0;
 }
 
@@ -109,32 +156,14 @@ int find_process_id(lua_State* L)
  */
 int find_cmdline_id(lua_State* L)
 {
-    printf("\033[2J\033[1;1H"); // Clear the console
-
-    process.name = lua_tostring(L, 1);
-    const char* sort = lua_tostring(L, 2);
-    char sortCmd[16] = "";
-
-    if (!sort) {
-        sort = "first";
-    } else {
-        if (strcmp(sort, "first") != 0 && strcmp(sort, "last") != 0) {
-            printf("[process] Invalid sort argument '%s'. Use 'first' or 'last'. Falling back to first\n", sort);
-            sort = "first";
-        }
-    }
-
-    if (strcmp(sort, "first") == 0) {
-        sortCmd[0] = '\0'; // No sorting
-    }
-    if (strcmp(sort, "last") == 0) {
-        strcpy(sortCmd, " | sort -r"); // Reverse the sorting to get latest PID
-    }
-
-    char command[256];
-    snprintf(command, sizeof(command), "pgrep -f \"%.*s\"%s", (int)strnlen(process.name, sizeof(command) - strlen(sortCmd) - 1), process.name, sortCmd);
-
-    stock_process_id(command);
-
+    printf("\033[2J\033[1;1H");
+    process_lookup.kind = PROCESS_LOOKUP_CMDLINE;
+    strncpy(process_lookup.name, lua_tostring(L, 1), sizeof(process_lookup.name) - 1);
+    process_lookup.name[sizeof(process_lookup.name) - 1] = '\0';
+    strncpy(process_lookup.sort, normalize_sort(lua_tostring(L, 2)), sizeof(process_lookup.sort) - 1);
+    process_lookup.sort[sizeof(process_lookup.sort) - 1] = '\0';
+    process_lookup_configured = true;
+    process.name = process_lookup.name;
+    wait_for_process(&process_lookup, auto_splitter_file);
     return 0;
 }

--- a/src/lasr/functions/process.c
+++ b/src/lasr/functions/process.c
@@ -159,11 +159,14 @@ int find_process_id(lua_State* L)
  */
 int find_cmdline_id(lua_State* L)
 {
-    printf("\033[2J\033[1;1H");
+    printf("\033[2J\033[1;1H"); // Clean the console
+
     process_lookup.kind = PROCESS_LOOKUP_CMDLINE;
     strncpy(process_lookup.name, lua_tostring(L, 1), sizeof(process_lookup.name) - 1);
+
     process_lookup.name[sizeof(process_lookup.name) - 1] = '\0';
     strncpy(process_lookup.sort, normalize_sort(lua_tostring(L, 2)), sizeof(process_lookup.sort) - 1);
+
     process_lookup.sort[sizeof(process_lookup.sort) - 1] = '\0';
     process_lookup_configured = true;
     process.name = process_lookup.name;

--- a/src/lasr/functions/readAddress.c
+++ b/src/lasr/functions/readAddress.c
@@ -98,6 +98,11 @@ char* read_memory_string(uint64_t mem_address, int buffer_size, int32_t* err)
  */
 int readAddress(lua_State* L)
 {
+    if (!process_is_attached()) {
+        lua_pushnil(L);
+        return 1;
+    }
+
     if (lua_gettop(L) == 0) {
         // There must be at least 2 arguments: type and address
         printf("[readAddress] Two arguments are required: type and address. Check your auto splitter code.\n");

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -186,6 +186,11 @@ bool validate_process_memory(pid_t pid, uintptr_t address, void* buffer, size_t 
  */
 int perform_sig_scan(lua_State* L)
 {
+    if (!process_is_attached()) {
+        lua_pushnil(L);
+        return 1;
+    }
+
     if (lua_gettop(L) != 2) {
         log_error("Invalid number of arguments: expected 2 (signature, offset)");
         lua_pushnil(L);

--- a/src/lasr/utils.c
+++ b/src/lasr/utils.c
@@ -4,6 +4,7 @@
 #include "./maps/maps.h"
 
 #include <glib.h>
+#include <signal.h>
 #include <stdatomic.h>
 #include <stdio.h>
 #include <string.h>
@@ -127,4 +128,12 @@ bool has_lua_function(lua_State* L, const char* name)
     bool exists = lua_isfunction(L, -1);
     lua_pop(L, 1);
     return exists;
+}
+
+/**
+ * Helper function that checks if the runtime is still attached to the current process.
+ */
+bool process_is_attached(void)
+{
+    return process.pid == 0 && kill(process.pid, 0) == 0;
 }

--- a/src/lasr/utils.c
+++ b/src/lasr/utils.c
@@ -6,8 +6,11 @@
 #include <glib.h>
 #include <stdatomic.h>
 #include <stdio.h>
+#include <string.h>
 
 game_process process;
+bool process_lookup_configured = false;
+process_query process_lookup;
 
 /**
  * Restarts the auto splitter by disabling it and re-enabling it again
@@ -105,4 +108,23 @@ const char* value_to_c_string(lua_State* L, int index)
         default:
             return "??";
     }
+}
+
+/**
+ * Utility function that checks if the autosplitter runtime should stop.
+ */
+bool runtime_should_stop(const char* current_file)
+{
+    return !atomic_load(&auto_splitter_enabled) || strcmp(current_file, auto_splitter_file) != 0;
+}
+
+/**
+ * Utility function that checks if the lua script has the provided function.
+ */
+bool has_lua_function(lua_State* L, const char* name)
+{
+    lua_getglobal(L, name);
+    bool exists = lua_isfunction(L, -1);
+    lua_pop(L, 1);
+    return exists;
 }

--- a/src/lasr/utils.h
+++ b/src/lasr/utils.h
@@ -54,3 +54,4 @@ bool try_find_process(const process_query* query);
 bool wait_for_process(const process_query* query, const char* current_file);
 bool runtime_should_stop(const char* current_file);
 bool has_lua_function(lua_State* L, const char* name);
+bool process_is_attached(void);

--- a/src/lasr/utils.h
+++ b/src/lasr/utils.h
@@ -32,7 +32,25 @@ typedef struct ProcessMap {
     char name[PATH_MAX];
 } ProcessMap;
 
+typedef enum {
+    PROCESS_LOOKUP_NAME,
+    PROCESS_LOOKUP_CMDLINE
+} process_lookup_kind;
+
+typedef struct process_query {
+    process_lookup_kind kind;
+    char name[PATH_MAX];
+    char sort[16];
+} process_query;
+
+extern process_query process_lookup;
+extern bool process_lookup_configured;
+
 bool restart_auto_splitter(void);
 uintptr_t find_base_address(const char* module);
 bool handle_memory_error(uint32_t err);
 const char* value_to_c_string(lua_State* L, int index);
+bool try_find_process(const process_query* query);
+bool wait_for_process(const process_query* query, const char* current_file);
+bool runtime_should_stop(const char* current_file);
+bool has_lua_function(lua_State* L, const char* name);


### PR DESCRIPTION
**Disclaimer:** I've used AI to assist me in making the code changes in this PR. Mostly to understand the current code and get me unstuck.

The manual tests I've done are to make sure this works are:
- starting the game with LibreSplit running and the autosplitter loaded to see if the `init` function runs properly
- starting the game, and then starting LibreSplit and loading the autosplittering to see if the `init` function runs properly
- quitting the game and restarting it to see if the `exit` and `init` functions run properly
- making sure the correct functions run when the process is connected and not connected as described below

I haven't tested any of the existing autosplitters since this would be a breaking change to pretty much all of them.

Test script using during development:
```lua
process("P4G.exe")

local current = { loading = false }

function startup()
	print("startup")
end

function update()
	print(current.loading)
	print(process_connected)
end

function init()
	print("init")
	current.loading = false
end

function split()
	print("split")
end

function start()
	print("start")
end

function reset()
	print("reset")
end

function isLoading()
	return current.loading
end

function exit()
	print("exit")
	current.loading = true
end
```

---

Marking this as draft since this is a pretty big change and I don't know if that's the way this problem should be approached (also my C skills are not great so there's probably some weird issues hiding that I don't see).

Currently the autosplitting runtime tears down the Lua state of the script whenever a process detaches. This means that doing things like pausing the timer on process exit and resuming it on process start is impossible with the current implementation.

This PR changes the runtime in a way so that after the first process attach after a script load, the runtime keeps running and the Lua state is kept until script unload. This makes the LibreSplit Autosplitting Runtime be more in line with LiveSplit's ASL runtime.


This PR also adds 3 new global functions/variables:
- `init()`- function that runs when the runtime attaches to the process
- `exit()`- function that runs when the runtime detaches from the process
- `process_connected` - a boolean that shows when the runtime is connected to a process

Not all script functions run when the runtime is connected to a process, only `update` and `isLoading` are running. I haven't checked how LiveSplit does (even though I probably should've), so there might be no point in limiting which functions run when not connected to a process. Due to this, all memory related process got a safeguard to not do anything if not connected to a process to avoid weird behaviour when running those functions without the game running.

To be clear, this is a **breaking change** so all current autosplitters would need to be updated with this in mind (and I don't think there's any way to do this without it being a breaking change, correct me if I'm wrong though).

As said at the start, I'm open to discussion on if this is even the correct way to go about it. Wouldn't be surprised if someone smarter than me could figure something better. :sweat_smile: 

Relevant Discord conversation: https://discord.com/channels/1381914148585078804/1381917206291550248/1500533003879714916

Also kinda relevant to issue #315 