### PR TITLE
Make sure game time setting from lua gets re-applied on reset.

### DIFF
--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -289,6 +289,7 @@ gboolean ls_app_window_step(gpointer data)
             }
             if (atomic_load(&call_reset)) {
                 timer_stop_and_reset(win);
+                atomic_store(&run_using_game_time_call, true);
                 atomic_store(&call_reset, 0);
             }
         }


### PR DESCRIPTION
I found that when an autosplitter that uses game time resets, the game time setting gets reverted to use real time which completely destroys games that use game time as their main timing method.

This PR calls `atomic_store(&run_using_game_time_call, true);` when reset happens to make sure the setting continues to be respected. Tested in my game that uses game time and resets now work.

I'm not too familiar with this project though so I'm not sure if this is the best fix.