### PR TITLE
Basic Md5 Hash Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Install the required dependencies:
 
     ```sh
     sudo apt update
-    sudo apt install build-essential libgtk-3-dev libjansson-dev meson libluajit-5.1-dev openssl
+    sudo apt install build-essential libgtk-3-dev libjansson-dev meson libluajit-5.1-dev libssl-dev
     ```
 
 - Arch-based systems

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ LibreSplit requires the following dependencies on your system to compile:
 - `meson`
 - `libgtk+-3.0`
 - `x11`
-- `libjansson`
-- `luajit`
+- `libjansson` (for reading JSON split files)
+- `luajit` (for the Lua Auto Splitter Runtime)
+- `openssl` (for the `md5sum` Lua function)
 
 and also the following (optional) runtime dependencies:
 
@@ -81,14 +82,14 @@ Install the required dependencies:
 
     ```sh
     sudo apt update
-    sudo apt install build-essential libgtk-3-dev libjansson-dev meson libluajit-5.1-dev cmake
+    sudo apt install build-essential libgtk-3-dev libjansson-dev meson libluajit-5.1-dev openssl
     ```
 
 - Arch-based systems
 
     ```sh
     sudo pacman -Sy
-    sudo pacman -S gtk3 jansson luajit git meson
+    sudo pacman -S gtk3 jansson luajit git meson openssl
     ```
 
 Clone the project:

--- a/docs/auto-splitters.md
+++ b/docs/auto-splitters.md
@@ -520,3 +520,13 @@ Usage:
 ```lua
 local maps = getMaps()
 ```
+
+## md5sum
+
+Returns a hex-digest of the file pointed by the path passed as argument, as a string. Mostly used for detecting different game versions.
+
+Usage:
+
+```lua
+local md5_to_compare = md5sum("path/to/my/awesome/game")
+```

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ gtk = dependency('gtk+-3.0')
 luajit = dependency('luajit')
 x11 = dependency('x11')
 jansson = dependency('jansson')
+openssl = dependency('openssl')
 
 libresplit_sources = files(
     'src/main.c',
@@ -57,6 +58,7 @@ libresplit_sources = files(
     'src/lasr/functions/shallow_copy_tbl.c',
     'src/lasr/functions/signature.c',
     'src/lasr/functions/sizeOf.c',
+    'src/lasr/functions/md5.c',
 
     # Keybinds
     'src/keybinds/keybinds.c',
@@ -116,7 +118,7 @@ executable(
     'libresplit',
     libresplit_sources,
     objects: [css_o],
-    dependencies: [threads, gtk, luajit, x11, jansson],
+    dependencies: [threads, gtk, luajit, x11, jansson, openssl],
     c_args: shared_c_flags,
     install: true,
 )

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -6,6 +6,7 @@
 
 #include "./maps/maps.h"
 #include "functions.h"
+#include "src/lasr/functions/md5.h"
 #include "utils.h"
 
 #include <lauxlib.h>
@@ -118,6 +119,7 @@ static const lasr_function luac_functions[] = {
     { "b_rshift", b_rshift },
     { "getMaps", getMaps },
     { "str2ida", str2ida },
+    { "md5sum", md5sum },
     { NULL, NULL }
 };
 

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -6,7 +6,6 @@
 
 #include "./maps/maps.h"
 #include "functions.h"
-#include "src/lasr/functions/md5.h"
 #include "utils.h"
 
 #include <lauxlib.h>

--- a/src/lasr/functions.h
+++ b/src/lasr/functions.h
@@ -5,6 +5,7 @@
 #include "functions/getMaps.h"
 #include "functions/getModuleSize.h"
 #include "functions/getPID.h"
+#include "functions/md5.h"
 #include "functions/print_tbl.h"
 #include "functions/process.h"
 #include "functions/readAddress.h"

--- a/src/lasr/functions/md5.c
+++ b/src/lasr/functions/md5.c
@@ -1,0 +1,81 @@
+#include "src/lasr/functions/md5.h"
+#include "lua.h"
+#include "src/logging.h"
+#include <openssl/evp.h>
+#include <stdio.h>
+
+const unsigned int MD5_FILE_READ_BUFFER_SIZE = 512;
+
+/**
+ * Takes a path, reads the file and calculates an MD5 hash of it
+ *
+ * @param L The lua stack
+ */
+int md5sum(lua_State* L)
+{
+    if (lua_gettop(L) != 1) {
+        // Call without arguments
+        printf("[md5sum] This function requires the path to a file to calculate the MD5 checksum");
+        lua_pushnil(L);
+        return 1;
+    }
+    if (!lua_isstring(L, 1)) {
+        // Called with a non-string argument
+        printf("The argument must be a string");
+        lua_pushnil(L);
+        return 1;
+    }
+    const char* file_path = lua_tostring(L, 1);
+    FILE* file_ptr = NULL;
+    file_ptr = fopen(file_path, "r");
+    if (file_ptr == NULL) {
+        printf("Error while opening the file for MD5 hashing");
+        lua_pushnil(L);
+        return 1;
+    }
+    EVP_MD_CTX* md5_context = NULL;
+    md5_context = EVP_MD_CTX_new();
+    if (!md5_context) {
+        LOG_ERR("Cannot create EVP Digest Context");
+        lua_pushnil(L);
+        return 1;
+    }
+    if (EVP_DigestInit_ex(md5_context, EVP_md5(), NULL) != 1) {
+        LOG_ERR("Cannot initialize EVP Digest Context");
+        EVP_MD_CTX_free(md5_context);
+        lua_pushnil(L);
+        return 1;
+    }
+    char buffer[MD5_FILE_READ_BUFFER_SIZE];
+    ssize_t bytes_read;
+    unsigned char md5_out[EVP_MAX_MD_SIZE];
+    do {
+        bytes_read = fread(buffer, 1, MD5_FILE_READ_BUFFER_SIZE, file_ptr);
+        // NOTE: [Penaz] [2026-06-05] Consider using ferror and feof to
+        // ^ check for read errors and EOF errors
+        if (EVP_DigestUpdate(md5_context, buffer, bytes_read) != 1) {
+            LOG_ERR("Failed updating the EVP Digest Context");
+            EVP_MD_CTX_free(md5_context);
+            fclose(file_ptr);
+            lua_pushnil(L);
+            return 1;
+        }
+    } while (bytes_read > 0);
+    unsigned int hash_length;
+    if (EVP_DigestFinal_ex(md5_context, md5_out, &hash_length) != 1) {
+        LOG_ERR("Failed finalizing the EVP Digest Context");
+        EVP_MD_CTX_free(md5_context);
+        fclose(file_ptr);
+        lua_pushnil(L);
+        return 1;
+    }
+    EVP_MD_CTX_free(md5_context);
+    fclose(file_ptr);
+    int pos = 0;
+    char output[hash_length * 2 + 1];
+    for (unsigned int i = 0; i < hash_length; i++) {
+        pos += snprintf(output + pos, sizeof(output) - pos, "%02x", md5_out[i]);
+    }
+    lua_pushstring(L, output);
+    return 1;
+}

--- a/src/lasr/functions/md5.c
+++ b/src/lasr/functions/md5.c
@@ -37,12 +37,14 @@ int md5sum(lua_State* L)
     md5_context = EVP_MD_CTX_new();
     if (!md5_context) {
         LOG_ERR("Cannot create EVP Digest Context");
+        fclose(file_ptr);
         lua_pushnil(L);
         return 1;
     }
     if (EVP_DigestInit_ex(md5_context, EVP_md5(), NULL) != 1) {
         LOG_ERR("Cannot initialize EVP Digest Context");
         EVP_MD_CTX_free(md5_context);
+        fclose(file_ptr);
         lua_pushnil(L);
         return 1;
     }

--- a/src/lasr/functions/md5.c
+++ b/src/lasr/functions/md5.c
@@ -4,7 +4,7 @@
 #include <openssl/evp.h>
 #include <stdio.h>
 
-const unsigned int MD5_FILE_READ_BUFFER_SIZE = 512;
+const unsigned int MD5_FILE_READ_BUFFER_SIZE = 4096;
 
 /**
  * Takes a path, reads the file and calculates an MD5 hash of it
@@ -21,28 +21,26 @@ int md5sum(lua_State* L)
     }
     if (!lua_isstring(L, 1)) {
         // Called with a non-string argument
-        printf("The argument must be a string");
+        printf("[md5sum] The argument must be a string");
         lua_pushnil(L);
         return 1;
     }
     const char* file_path = lua_tostring(L, 1);
-    FILE* file_ptr = NULL;
-    file_ptr = fopen(file_path, "r");
+    FILE* file_ptr = fopen(file_path, "r");
     if (file_ptr == NULL) {
-        printf("Error while opening the file for MD5 hashing");
+        printf("[md5sum] Error while opening the file for MD5 hashing");
         lua_pushnil(L);
         return 1;
     }
-    EVP_MD_CTX* md5_context = NULL;
-    md5_context = EVP_MD_CTX_new();
+    EVP_MD_CTX* md5_context = EVP_MD_CTX_new();
     if (!md5_context) {
-        LOG_ERR("Cannot create EVP Digest Context");
+        LOG_ERR("[md5sum] Cannot create EVP Digest Context");
         fclose(file_ptr);
         lua_pushnil(L);
         return 1;
     }
     if (EVP_DigestInit_ex(md5_context, EVP_md5(), NULL) != 1) {
-        LOG_ERR("Cannot initialize EVP Digest Context");
+        LOG_ERR("[md5sum] Cannot initialize EVP Digest Context");
         EVP_MD_CTX_free(md5_context);
         fclose(file_ptr);
         lua_pushnil(L);
@@ -50,13 +48,12 @@ int md5sum(lua_State* L)
     }
     char buffer[MD5_FILE_READ_BUFFER_SIZE];
     ssize_t bytes_read;
-    unsigned char md5_out[EVP_MAX_MD_SIZE];
     do {
         bytes_read = fread(buffer, 1, MD5_FILE_READ_BUFFER_SIZE, file_ptr);
         // NOTE: [Penaz] [2026-06-05] Consider using ferror and feof to
         // ^ check for read errors and EOF errors
         if (EVP_DigestUpdate(md5_context, buffer, bytes_read) != 1) {
-            LOG_ERR("Failed updating the EVP Digest Context");
+            LOG_ERR("[md5sum] Failed updating the EVP Digest Context");
             EVP_MD_CTX_free(md5_context);
             fclose(file_ptr);
             lua_pushnil(L);
@@ -64,8 +61,9 @@ int md5sum(lua_State* L)
         }
     } while (bytes_read > 0);
     unsigned int hash_length;
+    unsigned char md5_out[EVP_MAX_MD_SIZE];
     if (EVP_DigestFinal_ex(md5_context, md5_out, &hash_length) != 1) {
-        LOG_ERR("Failed finalizing the EVP Digest Context");
+        LOG_ERR("[md5sum] Failed finalizing the EVP Digest Context");
         EVP_MD_CTX_free(md5_context);
         fclose(file_ptr);
         lua_pushnil(L);
@@ -74,7 +72,7 @@ int md5sum(lua_State* L)
     EVP_MD_CTX_free(md5_context);
     fclose(file_ptr);
     int pos = 0;
-    char output[hash_length * 2 + 1];
+    char output[33];
     for (unsigned int i = 0; i < hash_length; i++) {
         pos += snprintf(output + pos, sizeof(output) - pos, "%02x", md5_out[i]);
     }

--- a/src/lasr/functions/md5.h
+++ b/src/lasr/functions/md5.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <lua.h>
+
+int md5sum(lua_State* L);


### PR DESCRIPTION
Should fix #365.

Adds an `md5sum` function that reads a file from disk, given the path and uses the EVP Digest system from OpenSSL to calculate an Md5 sum of it.