### PR TITLE
Added starting offset for the timer (start_offset in splits file)

### DIFF
--- a/docs/split-files.md
+++ b/docs/split-files.md
@@ -10,6 +10,7 @@ You can use splits located in [the resource repository](https://github.com/Libre
 | --------------- | ------------------ | --------------------------------------- |
 | `title`         | string             | Title string at top of window           |
 | `attempt_count` | int                | Number of attempts                      |
+| `start_offset`  | string (timestamp) | Time at which the timer will start      |
 | `start_delay`   | string (timestamp) | Non-negative delay until timer starts   |
 | `world_record`  | string             | Best known time                         |
 | `splits`        | array              | Array of [split objects](#split-object) |

--- a/src/gui/component/clock.c
+++ b/src/gui/component/clock.c
@@ -113,6 +113,7 @@ static void timer_draw(LSComponent* self_, const ls_game* game, const ls_timer* 
     }
 
     remove_class(self->time, "delay");
+    remove_class(self->time, "offset");
     remove_class(self->time, "behind");
     remove_class(self->time, "losing");
     remove_class(self->time, "best-split");
@@ -122,6 +123,8 @@ static void timer_draw(LSComponent* self_, const ls_game* game, const ls_timer* 
     }
     if (ls_timer_get_time(timer, true) <= 0) {
         add_class(self->time, "delay");
+    } else if (timer->started == 0 && ls_timer_get_time(timer, true) == game->start_offset) {
+    	add_class(self->time, "offset");
     } else {
         if (timer->curr_split == game->split_count
             && timer->split_info[curr]

--- a/src/gui/component/clock.c
+++ b/src/gui/component/clock.c
@@ -113,7 +113,6 @@ static void timer_draw(LSComponent* self_, const ls_game* game, const ls_timer* 
     }
 
     remove_class(self->time, "delay");
-    remove_class(self->time, "offset");
     remove_class(self->time, "behind");
     remove_class(self->time, "losing");
     remove_class(self->time, "best-split");

--- a/src/gui/component/clock.c
+++ b/src/gui/component/clock.c
@@ -121,10 +121,9 @@ static void timer_draw(LSComponent* self_, const ls_game* game, const ls_timer* 
     if (curr && curr == game->split_count) {
         curr = game->split_count - 1;
     }
-    if (ls_timer_get_time(timer, true) <= 0) {
+    if (ls_timer_get_time(timer, true) <= 0
+        || (timer->started == 0 && ls_timer_get_time(timer, true) == game->start_offset)) {
         add_class(self->time, "delay");
-    } else if (timer->started == 0 && ls_timer_get_time(timer, true) == game->start_offset) {
-    	add_class(self->time, "offset");
     } else {
         if (timer->curr_split == game->split_count
             && timer->split_info[curr]

--- a/src/gui/component/detailed-timer.c
+++ b/src/gui/component/detailed-timer.c
@@ -177,6 +177,7 @@ static void detailed_timer_draw(LSComponent* self_, const ls_game* game, const l
     }
 
     remove_class(self->time, "delay");
+    remove_class(self->time, "offset");
     remove_class(self->time, "behind");
     remove_class(self->time, "losing");
     remove_class(self->time, "best-split");
@@ -186,6 +187,8 @@ static void detailed_timer_draw(LSComponent* self_, const ls_game* game, const l
     }
     if (ls_timer_get_time(timer, true) <= 0) {
         add_class(self->time, "delay");
+    } else if (timer->started == 0 && ls_timer_get_time(timer, true) == game->start_offset) {
+        add_class(self->time, "offset");
     } else {
         if (timer->curr_split == game->split_count
             && timer->split_info[curr]

--- a/src/gui/component/detailed-timer.c
+++ b/src/gui/component/detailed-timer.c
@@ -185,10 +185,9 @@ static void detailed_timer_draw(LSComponent* self_, const ls_game* game, const l
     if (curr == game->split_count) {
         curr = game->split_count - 1;
     }
-    if (ls_timer_get_time(timer, true) <= 0) {
+    if (ls_timer_get_time(timer, true) <= 0
+        || (timer->started == 0 && ls_timer_get_time(timer, true) == game->start_offset)) {
         add_class(self->time, "delay");
-    } else if (timer->started == 0 && ls_timer_get_time(timer, true) == game->start_offset) {
-        add_class(self->time, "offset");
     } else {
         if (timer->curr_split == game->split_count
             && timer->split_info[curr]

--- a/src/gui/component/detailed-timer.c
+++ b/src/gui/component/detailed-timer.c
@@ -177,7 +177,6 @@ static void detailed_timer_draw(LSComponent* self_, const ls_game* game, const l
     }
 
     remove_class(self->time, "delay");
-    remove_class(self->time, "offset");
     remove_class(self->time, "behind");
     remove_class(self->time, "losing");
     remove_class(self->time, "best-split");

--- a/src/timer.c
+++ b/src/timer.c
@@ -754,9 +754,9 @@ static void reset_timer(ls_timer* timer)
     atomic_store(&run_running, false);
     timer->curr_split = 0;
     if (timer->game->start_offset) {
-    	timer->realTime = timer->game->start_offset; // Tobacom: Offset has priority over delay ig (you can't use both at the same time, don't know how to resolve this properly)
+        timer->realTime = timer->game->start_offset; // Tobacom: Offset has priority over delay ig (you can't use both at the same time, don't know how to resolve this properly)
     } else {
-    	timer->realTime = -timer->game->start_delay; // Start delay only applies to real time only
+        timer->realTime = -timer->game->start_delay; // Start delay only applies to real time only
     }
     timer->gameTime = 0;
     timer->usingGameTime = false;

--- a/src/timer.c
+++ b/src/timer.c
@@ -343,6 +343,12 @@ int ls_game_create(ls_game** game_ptr, const char* path, char** error_msg)
     if (ref) {
         game->height = json_integer_value(ref);
     }
+    // get offset
+    ref = json_object_get(json, "start_offset");
+    if (ref) {
+        game->start_offset = ls_time_value(
+            json_string_value(ref));
+    }
     // get delay
     ref = json_object_get(json, "start_delay");
     if (ref) {
@@ -561,6 +567,10 @@ int ls_game_save(const ls_game* game)
         ls_time_string_serialized(str, game->world_record);
         json_object_set_new(json, "world_record", json_string(str));
     }
+    if (game->start_offset) {
+        ls_time_string_serialized(str, game->start_offset);
+        json_object_set_new(json, "start_offset", json_string(str));
+    }
     if (game->start_delay) {
         ls_time_string_serialized(str, game->start_delay);
         json_object_set_new(json, "start_delay", json_string(str));
@@ -743,7 +753,11 @@ static void reset_timer(ls_timer* timer)
     timer->running = 0;
     atomic_store(&run_running, false);
     timer->curr_split = 0;
-    timer->realTime = -timer->game->start_delay; // Start delay only applies to real time only
+    if (timer->game->start_offset) {
+    	timer->realTime = timer->game->start_offset; // Tobacom: Offset has priority over delay ig (you can't use both at the same time, don't know how to resolve this properly)
+    } else {
+    	timer->realTime = -timer->game->start_delay; // Start delay only applies to real time only
+    }
     timer->gameTime = 0;
     timer->usingGameTime = false;
     timer->loading = false;

--- a/src/timer.h
+++ b/src/timer.h
@@ -21,6 +21,7 @@ typedef struct ls_game {
     int width;
     int height;
     long long world_record;
+    long long start_offset;
     long long start_delay;
     char** split_titles;
     char** split_icon_paths; // null if no icons


### PR DESCRIPTION
Added small feature where you can add starting offset to your splits file. Works almost the same as start_delay, but instead of delaying, the timer will now start from the specified time. (It's usefull for example while speedrunning Portal 2, where you can have different starting saves and ofc different starting times). But the start_offset is currently overriding the start_delay and I currently don't know how to properly resolve this (maybe impossible to have start_offset and start_delay specified at the same time)