### PR TITLE
Add game/script init/stop funcs

### DIFF
--- a/docs/auto-splitters.md
+++ b/docs/auto-splitters.md
@@ -20,10 +20,27 @@
 ```lua
 process('GameBlaBlaBla.exe')
 ```
-* With this line, LibreSplit will repeatedly attempt to find this process and will not continue script execution until it is found. This is limited to 15 characters in length (the ones present in `/proc/<pid>/stat`).
 
-* Next we have to define the basic functions. Not all are required and the ones that are required may change depending on the game or end goal, like if loading screens are included or not.
-    * The order at which these run is the same as they are documented below.
+* With this line, LibreSplit will repeatedly attempt to find this process and will not continue script execution until it is found.
+
+The `process()` function has a few arguments it accepts.
+
+```lua
+process(<gamename>, [first/last], [{ignore, table}])
+
+process('GameBlaBlaBla.exe', 'first', {'wine', 'start.exe', 'GameUtil'})
+```
+
+1. The name of the game to find.
+
+2. The first or last PID found, in the case of multiple matches PID 20 vs 200. The default is `first`.
+
+3. Processes to ignore. The default is `{'wine', 'start.exe'}`.
+IT IS IMPORTANT TO INCLUDE THESE IF YOU PASS A VALUE.
+`wine` launches programs with Window's `start.exe`, if you attach to either of these you clearly will not find addresses you're looking for.
+
+Next we have to define the basic functions. Not all are required and the ones that are required may change depending on the game or end goal, like if loading screens are included or not.
+(The order at which these run is the same as they are documented below.)
 
 ### `startup`
  The purpose of this function is to specify how many times LibreSplit checks memory values and executes functions each second, the default is 60Hz. Usually, 60Hz is fine and this function can remain undefined. However, it's there if you need it. Its also useful to change other configuration about the script.

--- a/docs/auto-splitters.md
+++ b/docs/auto-splitters.md
@@ -22,12 +22,6 @@ process('GameBlaBlaBla.exe')
 ```
 * With this line, LibreSplit will repeatedly attempt to find this process and will not continue script execution until it is found. This is limited to 15 characters in length (the ones present in `/proc/<pid>/stat`).
 
-If you want to use longer names or check the entire command line use the `cmdline` function:
-
-```lua
-cmdline('MyGameHasAVeryLongName.exe')
-```
-
 * Next we have to define the basic functions. Not all are required and the ones that are required may change depending on the game or end goal, like if loading screens are included or not.
     * The order at which these run is the same as they are documented below.
 

--- a/docs/auto-splitters.md
+++ b/docs/auto-splitters.md
@@ -208,6 +208,55 @@ end
 ```
 * Pretty self explanatory, since we want to return whenever we are currently in a loading screen, we can just send our current isLoading status, same as start.
 
+
+### `game_init`
+The purpose of this function is to run code when the game starts or restarts.
+
+_Note: The function `resumeTimer()` resumes a paused run (optional)._
+
+```lua
+process('GameBlaBlaBla.exe')
+local game_died = false
+
+function game_init()
+    if game_died then
+        loading = true
+        resumeTimer()
+        game_died = false
+    end
+end
+```
+
+### `game_stop`
+The purpose of this function is to run code when the game is killed, crashes or otherwise stops.
+
+Returning `true` will reset the run, similar to the `reset` function above. Otherwise returning `false` can be handled manaully by pausing the timer with `pauseTimer()` or leaving the timer going by doing nothing. If the run is not reset, the autosplitter waits for the process according to the last `Process(name)` used.
+
+```lua
+process('GameBlaBlaBla.exe')
+local game_died = false
+
+function game_stop()
+    loading = true
+    game_died = true
+    pauseTimer()
+    process('GameBlaBlaBla.exe')
+    return false
+end
+```
+
+### `script_stop`
+
+The purpose of this function is to run code when the autosplitter is disabled or stops.
+
+```lua
+process('GameBlaBlaBla.exe')
+
+function script_stop()
+    print("Quit autosplitting")
+end
+```
+
 # `reset`
 Instantly resets the timer. Use with caution.
 * Runs every 1000 / `refreshRate` milliseconds.

--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,7 @@ libresplit_sources = files(
     'src/lasr/auto-splitter.c',
     'src/lasr/utils.c',
     'src/lasr/maps/maps.c',
+    'src/lasr/functions/timerControl.c',
     'src/lasr/functions/bitwise.c',
     'src/lasr/functions/getBaseAddress.c',
     'src/lasr/functions/getModuleSize.c',

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -270,17 +270,13 @@ gboolean ls_app_window_step(gpointer data)
                 timer_split(win);
                 atomic_store(&call_split, 0);
             }
-            if (atomic_load(&toggle_loading)) {
-                win->timer->loading = !win->timer->loading;
-
-                if (win->timer->running) {
-                    if (win->timer->loading) {
-                        timer_pause(win);
-                    } else {
-                        timer_unpause(win);
-                    }
+            win->timer->loading = atomic_load(&b_is_loading);
+            if (win->timer->running) {
+                if (win->timer->loading) {
+                    timer_pause(win);
+                } else {
+                    timer_unpause(win);
                 }
-                atomic_store(&toggle_loading, 0);
             }
             if (atomic_load(&update_game_time)) {
                 // Update the timer with the game time from auto-splitter

--- a/src/gui/app_window.c
+++ b/src/gui/app_window.c
@@ -283,6 +283,11 @@ gboolean ls_app_window_step(gpointer data)
                 win->timer->gameTime = atomic_load(&game_time_value);
                 atomic_store(&update_game_time, false);
             }
+            if (!atomic_load(&run_running)) {
+                timer_stop(win);
+            } else if (atomic_load(&run_started)) {
+                timer_start(win);
+            }
             if (atomic_load(&call_reset)) {
                 timer_stop_and_reset(win);
                 atomic_store(&run_using_game_time_call, true);

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -588,6 +588,24 @@ void run_auto_splitter(void)
             lua_pushstring(L, process.name);
             // currently 0 means first, above means last
             lua_pushstring(L, process.sort_fl > 0 ? "last" : "first");
+            // rebuild ignore table, not the best efficiency
+            // could pass arg to find_process_id() ? or fake lua string to say 'leave table alone' ?
+            if (process.ignore_names[0] != 0) {
+                int ignore_cnt = 1, i = 1; // lua index
+                while (process.ignore_names[ignore_cnt] != 0) {
+                    ignore_cnt++;
+                }
+                lua_newtable(L);
+                ignore_cnt = 0;
+                i = lua_gettop(L);
+                while (process.ignore_names[ignore_cnt] != 0) {
+                    lua_pushinteger(L, i);
+                    lua_pushstring(L, process.ignore_names[ignore_cnt]);
+                    ignore_cnt++;
+                    i++;
+                    lua_settable(L, -3); // because you pushed 2 values, back 1 more is -3
+                }
+            }
             find_process_id(L);
         }
 

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -107,6 +107,8 @@ static const lasr_function luac_functions[] = {
     { "getPID", getPID },
     { "getModuleSize", getModuleSize },
     { "shallow_copy_tbl", shallow_copy_tbl },
+    { "pauseTimer", pauseTimer },
+    { "resumeTimer", resumeTimer },
     { "print_tbl", print_tbl },
     { "b_and", b_and },
     { "b_or", b_or },
@@ -367,6 +369,52 @@ void start(lua_State* L)
 }
 
 /**
+ * The game_init() LASR function.
+ *
+ * Executes the code in the game_init() function of the auto splitter.
+ *
+ * @param L The Lua State
+ */
+void game_init(lua_State* L)
+{
+    call_va(L, "game_init", "");
+}
+
+/**
+ * The game_stop() LASR function.
+ *
+ * Executes the code in the game_stop() function of the auto splitter.
+ *
+ * @param L The Lua State
+ */
+void game_stop(lua_State* L)
+{
+    bool shouldReset;
+
+    if (call_va(L, "game_stop", ">b", &shouldReset)) {
+        if (shouldReset) {
+            atomic_store(&call_reset, true);
+            // Assume these happen instantly to avoid any desync
+            atomic_store(&run_started, false);
+            atomic_store(&run_running, false);
+        }
+    }
+    lua_pop(L, 1); // Remove the return value from the stack
+}
+
+/**
+ * The script_stop() LASR function.
+ *
+ * Executes the code in the script_stop() function of the auto splitter.
+ *
+ * @param L The Lua State
+ */
+void script_stop(lua_State* L)
+{
+    call_va(L, "script_stop", "");
+}
+
+/**
  * The split() LASR function.
  *
  * Executes the code in the split() function of the auto splitter.
@@ -485,6 +533,18 @@ void run_auto_splitter(void)
     bool start_exists = lua_isfunction(L, -1);
     lua_pop(L, 1); // Remove 'start' from the stack
 
+    lua_getglobal(L, "game_init");
+    bool game_init_exists = lua_isfunction(L, -1);
+    lua_pop(L, 1); // Remove 'game_init' from the stack
+
+    lua_getglobal(L, "game_stop");
+    bool game_stop_exists = lua_isfunction(L, -1);
+    lua_pop(L, 1); // Remove 'game_stop' from the stack
+
+    lua_getglobal(L, "script_stop");
+    bool script_stop_exists = lua_isfunction(L, -1);
+    lua_pop(L, 1); // Remove 'script_stop' from the stack
+
     lua_getglobal(L, "split");
     bool split_exists = lua_isfunction(L, -1);
     lua_pop(L, 1); // Remove 'split' from the stack
@@ -516,58 +576,94 @@ void run_auto_splitter(void)
     printf("Refresh rate: %d\n", refresh_rate);
     int rate = 1000000 / refresh_rate;
 
-    while (1) {
-        struct timespec clock_start;
-        clock_gettime(CLOCK_MONOTONIC, &clock_start);
+    atomic_store(&auto_splitter_running, true);
 
-        if (!atomic_load(&auto_splitter_enabled) || strcmp(current_file, auto_splitter_file) != 0 || !process_exists() || process.pid == 0) {
+    while (atomic_load(&auto_splitter_enabled) && strcmp(current_file, auto_splitter_file) == 0) {
+        // some games may try to do something to find processes or multiple games
+        // see PR 360 - remakes, different versions, etc
+        // if you HAVE a process you're trying to attach to, then do so
+        // otherwise idk, you have some weird autosplitter that does...stuff?
+        // process.pid = 0;
+        while (process.pid == 0 && process.name) {
+            lua_pushstring(L, process.name);
+            // currently 0 means first, above means last
+            lua_pushstring(L, process.sort_fl > 0 ? "last" : "first");
+            find_process_id(L);
+        }
+
+        if (game_init_exists) {
+            game_init(L);
+        }
+
+        while (atomic_load(&auto_splitter_running) && process_exists() && process.pid != 0) {
+            struct timespec clock_start;
+            clock_gettime(CLOCK_MONOTONIC, &clock_start);
+
+            if (state_exists) {
+                state(L);
+            }
+
+            if (update_exists) {
+                update(L);
+            }
+
+            if (gameTime_exists && use_game_time && atomic_load(&run_started) && atomic_load(&run_running)) {
+                gameTime(L);
+            }
+
+            if (start_exists && !atomic_load(&run_started)) {
+                start(L);
+            }
+
+            if (split_exists && atomic_load(&run_started)) {
+                split(L);
+            }
+
+            if (is_loading_exists) {
+                is_loading(L);
+            }
+
+            if (reset_exists && atomic_load(&run_running)) {
+                reset(L);
+            }
+
+            // Clear the memory maps cache if needed
+            maps_cache_cycles_value--;
+            if (maps_cache_cycles_value < 1) {
+                maps_clearCache();
+                maps_cache_cycles_value = maps_cache_cycles;
+                // printf("Cleared maps cache\n");
+            }
+
+            struct timespec clock_end;
+            clock_gettime(CLOCK_MONOTONIC, &clock_end);
+            long long duration = (clock_end.tv_sec - clock_start.tv_sec) * 1000000 + (clock_end.tv_nsec - clock_start.tv_nsec) / 1000;
+            // printf("duration: %llu\n", duration);
+            if (duration < rate) {
+                usleep(rate - duration);
+            }
+        }
+        // process was running, but is now dead. loop at start of outer-while refinds it
+        process.pid = 0;
+
+        if (!atomic_load(&auto_splitter_enabled) || !atomic_load(&auto_splitter_running)) {
+            break; // should this be ahead of game stop ? reset functionality may bork things
+        }
+
+        if (game_stop_exists) {
+            game_stop(L);
+        }
+        // game_stop may signal reset
+        if (atomic_load(&call_reset)) {
             break;
         }
-
-        if (state_exists) {
-            state(L);
-        }
-
-        if (update_exists) {
-            update(L);
-        }
-
-        if (gameTime_exists && use_game_time && atomic_load(&run_started) && atomic_load(&run_running)) {
-            gameTime(L);
-        }
-
-        if (start_exists && !atomic_load(&run_started) && !atomic_load(&run_running)) {
-            start(L);
-        }
-
-        if (split_exists && atomic_load(&run_started)) {
-            split(L);
-        }
-
-        if (is_loading_exists) {
-            is_loading(L);
-        }
-
-        if (reset_exists && atomic_load(&run_running)) {
-            reset(L);
-        }
-
-        // Clear the memory maps cache if needed
-        maps_cache_cycles_value--;
-        if (maps_cache_cycles_value < 1) {
-            maps_clearCache();
-            maps_cache_cycles_value = maps_cache_cycles;
-            // printf("Cleared maps cache\n");
-        }
-
-        struct timespec clock_end;
-        clock_gettime(CLOCK_MONOTONIC, &clock_end);
-        long long duration = (clock_end.tv_sec - clock_start.tv_sec) * 1000000 + (clock_end.tv_nsec - clock_start.tv_nsec) / 1000;
-        // printf("duration: %llu\n", duration);
-        if (duration < rate) {
-            usleep(rate - duration);
-        }
     }
+
+    if (script_stop_exists) {
+        script_stop(L);
+    }
+
+    atomic_store(&auto_splitter_running, false);
 
     lua_close(L);
 }

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -100,7 +100,6 @@ static const luaL_Reg lj_lib_load[] = {
  */
 static const lasr_function luac_functions[] = {
     { "process", find_process_id },
-    { "cmdline", find_cmdline_id },
     { "getBaseAddress", getBaseAddress },
     { "readAddress", readAddress },
     { "sizeOf", size_of },

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -41,13 +41,12 @@ atomic_bool auto_splitter_enabled = true; /*!< Defines if the auto splitter is e
 atomic_bool auto_splitter_running = false; /*!< Defines if the auto splitter is running */
 atomic_bool call_start = false; /*!< True if the auto splitter is requesting for a run to start */
 atomic_bool call_split = false; /*!< True if the auto splitter is requesting to split */
-atomic_bool toggle_loading = false;
+atomic_bool b_is_loading = true; /*!< True if the game is loading to pause the timer */
 atomic_bool call_reset = false; /*!< True if the auto splitter is requesting a run reset */
 atomic_bool run_using_game_time_call; /*!< True if startup has run and a new value for using game time has been set by the auto splitter */
 atomic_bool run_using_game_time; /*!< True if the auto splitter is requesting to use game time, false for real time */
 atomic_bool run_started = false; /*!< Wheter a run was started or not, same as timer->started but accessible from the auto splitter thread */
 atomic_bool run_running = false; /*!< Wheter we are running or not, same as timer->running but accessible from the auto splitter thread */
-bool prev_is_loading; /*!< The previous frame "is_loading" state */
 
 /**
  * Disable possibly dangerous functions in LASR.
@@ -395,11 +394,9 @@ void split(lua_State* L)
 void is_loading(lua_State* L)
 {
     bool loading;
-    if (call_va(L, "isLoading", ">b", &loading)) {
-        if (loading != prev_is_loading) {
-            atomic_store(&toggle_loading, true);
-            prev_is_loading = !prev_is_loading;
-        }
+    if (call_va(L, "isLoading", ">b", &loading)
+        && loading != b_is_loading) {
+        atomic_store(&b_is_loading, loading);
     }
     lua_pop(L, 1); // Remove the return value from the stack
 }

--- a/src/lasr/auto-splitter.h
+++ b/src/lasr/auto-splitter.h
@@ -15,13 +15,12 @@ extern atomic_bool auto_splitter_enabled;
 extern atomic_bool auto_splitter_running;
 extern atomic_bool call_start;
 extern atomic_bool call_split;
-extern atomic_bool toggle_loading;
+extern atomic_bool b_is_loading;
 extern atomic_bool call_reset;
 extern atomic_bool run_using_game_time_call;
 extern atomic_bool run_using_game_time;
 extern atomic_bool run_started;
 extern atomic_bool run_running;
-extern bool prev_is_loading;
 
 /**
  * Defines a Lua Auto Splitter Runtime Function.

--- a/src/lasr/functions.h
+++ b/src/lasr/functions.h
@@ -13,3 +13,4 @@
 #include "functions/signature.h"
 #include "functions/sizeOf.h"
 #include "functions/strtoida.h"
+#include "functions/timerControl.h"

--- a/src/lasr/functions/process.c
+++ b/src/lasr/functions/process.c
@@ -13,6 +13,21 @@
 extern atomic_bool auto_splitter_enabled; /*!< Defines if the auto splitter is enabled */
 
 /**
+ * Compares string against ignore names
+ *
+ * @param n the name of the process to compare
+ *
+ * @return 1 for not in ignore names, 0 for found in ignore names
+ */
+int name_okay(const char* n)
+{
+    int i = 0;
+    while (process.ignore_names[i] != 0 && strstr(n, process.ignore_names[i]) == 0)
+        i++;
+    return process.ignore_names[i] == 0;
+}
+
+/**
  * Finds a process by crawling /proc for proc_name
  *
  * @param proc_name the name of the process
@@ -33,46 +48,20 @@ pid_t find_process_by_name(const char* proc_name, int fl)
         return pid;
     }
 
-    // skip '.', '..', and non-digit paths, these should always come before PIDs, procfs is special
+    // procfs is special so the order should always be : "." ".." "a-Z" "PIDs 1..10..15..22..230"
+    // skip '.', '..', and non-digit paths - NOP, formatter doesn't like { } below while
     while ((entry = readdir(dir)) != NULL && !isdigit(*entry->d_name)) { }
-    // NOP, formatter doesn't like readability of { } down here
 
     entry = readdir(dir); // pid 1, init may be running stuff
     // gets rid of a strcmp() every loop :)
 
     while ((entry = readdir(dir)) != NULL) {
-        int match = 0; // used more for inside the loop to skip checking comm AND cmdline
-        char comm_path[PATH_MAX + 100];
         char cmdl_path[PATH_MAX + 100];
-
-        snprintf(comm_path, sizeof(comm_path), "/proc/%s/comm", entry->d_name);
-        FILE* fp = fopen(comm_path, "r");
-        if (fp) {
-            char comm[512] = { 0 };
-            if (fgets(comm, sizeof(comm), fp) != NULL) {
-                // ignore wine starting processes (see HACK below)
-                if (strstr(comm, proc_name) != 0
-                    && strstr(comm, "wine") == 0
-                    && strstr(comm, "start.exe") == 0) {
-                    match = 1;
-                    pid = strtoul(entry->d_name, NULL, 10);
-                    if (fl == 0) {
-                        fclose(fp);
-                        break; // first hit, otherwise keep going for last
-                    }
-                }
-            }
-            fclose(fp);
-        }
-
-        if (match) {
-            continue; // skip lengthy cmdline check if comm matches
-        }
-
         snprintf(cmdl_path, sizeof(cmdl_path), "/proc/%s/cmdline", entry->d_name);
-        fp = fopen(cmdl_path, "r");
+
+        FILE* fp = fopen(cmdl_path, "r");
         if (fp) {
-            char cmdl[2048] = { ' ' }; // can be much bigger than comm
+            char cmdl[2048] = { ' ' }; // only seen discord and chromium get bigger than this
             cmdl[2047] = 0x0;
             if (fgets(cmdl, 2048, fp) != NULL) {
                 // turn the 0x0 spaces into ascii 0x20 spaces
@@ -81,10 +70,7 @@ pid_t find_process_by_name(const char* proc_name, int fl)
                         cmdl[i] = 0x20;
                     }
                 }
-                // ignore wine starting processes (see HACK below)
-                if (strstr(cmdl, proc_name) != 0
-                    && strstr(cmdl, "wine") == 0
-                    && strstr(cmdl, "start.exe") == 0) {
+                if (strstr(cmdl, proc_name) && name_okay(cmdl)) {
                     pid = strtoul(entry->d_name, NULL, 10);
                     if (fl == 0) {
                         fclose(fp);
@@ -130,14 +116,46 @@ int find_process_id(lua_State* L)
         printf("[process] Invalid sort argument '%s'. Use 'first' or 'last'. Falling back to first\n", sort);
     }
 
+    // clear any old buffers before rebuilding ignore list
+    // TODO: see run_auto_splitter, restarting a game rebuilds the table =/
+    memset(process.mono_ignore_names, 0, 2048); // sizes in utils.h
+    memset(process.ignore_names, 0, sizeof(char*) * 100);
+
+    if (lua_istable(L, 3)) {
+        size_t ignore_pos = 0; // ^inside mono array
+        size_t ignore_cnt = 0; // hardcode of words in default_ignore_list
+        size_t name_len = 0;
+        ignore_cnt = 0;
+
+        lua_pushnil(L); // bootstraps lua_next - see print_tbl.c
+        while (lua_next(L, 3) != 0) {
+            lua_pushvalue(L, -2); // key/index + value
+            // __attribute__((unused)) const char* jnk = lua_tostring(L, -1); // key
+            const char* ignore_name = lua_tostring(L, -2); // value, process name to ignore
+            name_len = strlen(ignore_name);
+            if (ignore_pos + name_len > 2047 || ignore_cnt > 98) {
+                printf("[process] oversized ignore list! Currently hardcoded max size of 2048 for all names and 100 max names. Ignoring from %s on\n", ignore_name);
+                lua_pop(L, 2);
+                break;
+            }
+            memcpy(&process.mono_ignore_names[ignore_pos], ignore_name, name_len);
+            process.ignore_names[ignore_cnt] = &process.mono_ignore_names[ignore_pos];
+            ignore_pos += name_len + 1; // skip null byte - text1\0text
+            ignore_cnt++;
+            lua_pop(L, 2);
+        }
+    } else {
+        // TODO: I'm sure "steam" also has some conflicts? (default list below)
+        memcpy(process.mono_ignore_names, "wine\0start.exe", 14);
+        process.ignore_names[0] = process.mono_ignore_names;
+        process.ignore_names[1] = process.mono_ignore_names + 5; // sizeof("wine") + 1(null byte)
+    }
+
     while (atomic_load(&auto_splitter_enabled)) {
         process.pid = find_process_by_name(process.name, process.sort_fl);
         pid_t last_pid = process.pid;
 
-        // HACK: wine can run a 'start.exe' command to launch a game
-        // at that time, the game's process name is in wine's cmdline args
-        // also, some games launch and then change names, or launch the game proper
-        // that's not the game :)
+        // HACK: some games run from launchers and change names after launch
         // may also be good enough to check the base/dll addys ? 0 indicates wine?
         usleep(200000); // Sleep for 200ms ? may be game/hardware dependant
         process.pid = find_process_by_name(process.name, process.sort_fl);

--- a/src/lasr/functions/process.c
+++ b/src/lasr/functions/process.c
@@ -2,6 +2,8 @@
 
 #include "../utils.h"
 
+#include <ctype.h>
+#include <dirent.h>
 #include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -11,51 +13,91 @@
 extern atomic_bool auto_splitter_enabled; /*!< Defines if the auto splitter is enabled */
 
 /**
- * Executes a command, piping its output into an output string.
+ * Finds a process by crawling /proc for proc_name
  *
- * @param command The command to execute.
- * @param output Pointer to a string that will contain the command output.
+ * @param proc_name the name of the process
+ *
+ * @param fl to grab the first or last process
+ *
+ * @return PID or 0 for error or not found
  */
-void execute_command(const char* command, char* output)
+pid_t find_process_by_name(const char* proc_name, int fl)
 {
-    char buffer[4096];
-    FILE* pipe = popen(command, "r");
-    if (!pipe) {
-        fprintf(stderr, "Error executing command: %s\n", command);
-        exit(1);
+    DIR* dir;
+    struct dirent* entry;
+    pid_t pid = 0;
+
+    dir = opendir("/proc");
+    if (dir == NULL) {
+        perror("opendir /proc failed");
+        return pid;
     }
 
-    while (fgets(buffer, 128, pipe) != NULL) {
-        strcat(output, buffer);
-    }
+    // skip '.', '..', and non-digit paths, these should always come before PIDs, procfs is special
+    while ((entry = readdir(dir)) != NULL && !isdigit(*entry->d_name)) { }
+    // NOP, formatter doesn't like readability of { } down here
 
-    pclose(pipe);
-}
+    entry = readdir(dir); // pid 1, init may be running stuff
+    // gets rid of a strcmp() every loop :)
 
-void stock_process_id(const char* pid_command)
-{
-    char pid_output[PATH_MAX + 100];
-    pid_output[0] = '\0';
+    while ((entry = readdir(dir)) != NULL) {
+        int match = 0; // used more for inside the loop to skip checking comm AND cmdline
+        char comm_path[PATH_MAX + 100];
+        char cmdl_path[PATH_MAX + 100];
 
-    while (atomic_load(&auto_splitter_enabled)) {
-        execute_command(pid_command, pid_output);
-        process.pid = strtoul(pid_output, NULL, 10);
-        if (process.pid) {
-            size_t newlinePos = strcspn(pid_output, "\n");
-            if (newlinePos != strlen(pid_output) - 1 && pid_output[0] != '\0') {
-                printf("Multiple PID's found for process: %s\n", process.name);
+        snprintf(comm_path, sizeof(comm_path), "/proc/%s/comm", entry->d_name);
+        FILE* fp = fopen(comm_path, "r");
+        if (fp) {
+            char comm[512] = { 0 };
+            if (fgets(comm, sizeof(comm), fp) != NULL) {
+                // ignore wine starting processes (see HACK below)
+                if (strstr(comm, proc_name) != 0
+                    && strstr(comm, "wine") == 0
+                    && strstr(comm, "start.exe") == 0) {
+                    match = 1;
+                    pid = strtoul(entry->d_name, NULL, 10);
+                    if (fl == 0) {
+                        fclose(fp);
+                        break; // first hit, otherwise keep going for last
+                    }
+                }
             }
-            break;
-        } else {
-            printf("%s isn't running.\n", process.name);
-            usleep(100000); // Sleep for 100ms
+            fclose(fp);
+        }
+
+        if (match) {
+            continue; // skip lengthy cmdline check if comm matches
+        }
+
+        snprintf(cmdl_path, sizeof(cmdl_path), "/proc/%s/cmdline", entry->d_name);
+        fp = fopen(cmdl_path, "r");
+        if (fp) {
+            char cmdl[2048] = { ' ' }; // can be much bigger than comm
+            cmdl[2047] = 0x0;
+            if (fgets(cmdl, 2048, fp) != NULL) {
+                // turn the 0x0 spaces into ascii 0x20 spaces
+                for (int i = 0; i < 2047; i++) {
+                    if (cmdl[i] == 0) {
+                        cmdl[i] = 0x20;
+                    }
+                }
+                // ignore wine starting processes (see HACK below)
+                if (strstr(cmdl, proc_name) != 0
+                    && strstr(cmdl, "wine") == 0
+                    && strstr(cmdl, "start.exe") == 0) {
+                    pid = strtoul(entry->d_name, NULL, 10);
+                    if (fl == 0) {
+                        fclose(fp);
+                        break; // first hit, otherwise keep going for last
+                    }
+                }
+            }
+            fclose(fp);
         }
     }
 
-    printf("Process: %s\n", process.name);
-    printf("PID: %u\n", process.pid);
-    process.base_address = find_base_address(NULL);
-    process.dll_address = process.base_address;
+    closedir(dir);
+    return pid;
 }
 
 /**
@@ -69,72 +111,47 @@ int find_process_id(lua_State* L)
 {
     printf("\033[2J\033[1;1H"); // Clear the console
 
-    process.name = lua_tostring(L, 1);
+    const char* tmp_name = lua_tostring(L, 1);
     const char* sort = lua_tostring(L, 2);
-    char sortCmd[16] = "";
+    // if you're not first, you're last ('last' is the only valid argument)
+    int is_first = sort ? strcmp(sort, "first") : -1;
+    int is_last = sort ? strcmp(sort, "last") : -1;
+    process.sort_fl = is_last == 0 ? 1 : 0;
 
-    if (!sort) {
-        sort = "first";
-    } else {
-        if (strcmp(sort, "first") != 0 && strcmp(sort, "last") != 0) {
-            printf("[process] Invalid sort argument '%s'. Use 'first' or 'last'. Falling back to first\n", sort);
-            sort = "first";
+    if (process.name) {
+        free(process.name); // clear in case something is using it
+        process.name = 0; // the auto-splitter loop checks for name
+    }
+    // the lua stack will constantly realloc and the process name above WILL get corrupted
+    process.name = (char*)calloc(strlen(tmp_name) + 1, sizeof(char));
+    memcpy(process.name, tmp_name, strlen(tmp_name));
+
+    if (sort && is_first != 0 && is_last != 0) {
+        printf("[process] Invalid sort argument '%s'. Use 'first' or 'last'. Falling back to first\n", sort);
+    }
+
+    while (atomic_load(&auto_splitter_enabled)) {
+        process.pid = find_process_by_name(process.name, process.sort_fl);
+        pid_t last_pid = process.pid;
+
+        // HACK: wine can run a 'start.exe' command to launch a game
+        // at that time, the game's process name is in wine's cmdline args
+        // also, some games launch and then change names, or launch the game proper
+        // that's not the game :)
+        // may also be good enough to check the base/dll addys ? 0 indicates wine?
+        usleep(200000); // Sleep for 200ms ? may be game/hardware dependant
+        process.pid = find_process_by_name(process.name, process.sort_fl);
+        if (process.pid && process.pid == last_pid) {
+            break;
         }
+        printf("%s isn't running.\n", process.name);
+        usleep(100000); // Sleep for 100ms
     }
 
-    if (strcmp(sort, "first") == 0) {
-        sortCmd[0] = '\0'; // No sorting
-    }
-    if (strcmp(sort, "last") == 0) {
-        strcpy(sortCmd, " | sort -r"); // Reverse the sorting to get latest PID
-    }
-
-    char command[256];
-    snprintf(command, sizeof(command), "pgrep \"%.*s\"%s", (int)strnlen(process.name, sizeof(command) - strlen(sortCmd) - 1), process.name, sortCmd);
-
-    stock_process_id(command);
-
-    return 0;
-}
-
-/**
- * Finds the ID of the process indicated by the Lua Auto Splitter using full commandline grepping.
- *
- *  NOTE: [Penaz] [2026-04-25] This differs from find_process_id only by the -f argument. Consider
- *  ^ merging the command creation into a single function instead of duplicating code.
- *
- * @param L The Lua State.
- *
- * @return Always zero.
- */
-int find_cmdline_id(lua_State* L)
-{
-    printf("\033[2J\033[1;1H"); // Clear the console
-
-    process.name = lua_tostring(L, 1);
-    const char* sort = lua_tostring(L, 2);
-    char sortCmd[16] = "";
-
-    if (!sort) {
-        sort = "first";
-    } else {
-        if (strcmp(sort, "first") != 0 && strcmp(sort, "last") != 0) {
-            printf("[process] Invalid sort argument '%s'. Use 'first' or 'last'. Falling back to first\n", sort);
-            sort = "first";
-        }
-    }
-
-    if (strcmp(sort, "first") == 0) {
-        sortCmd[0] = '\0'; // No sorting
-    }
-    if (strcmp(sort, "last") == 0) {
-        strcpy(sortCmd, " | sort -r"); // Reverse the sorting to get latest PID
-    }
-
-    char command[256];
-    snprintf(command, sizeof(command), "pgrep -f \"%.*s\"%s", (int)strnlen(process.name, sizeof(command) - strlen(sortCmd) - 1), process.name, sortCmd);
-
-    stock_process_id(command);
+    printf("Process: %s\n", process.name);
+    printf("PID: %u\n", process.pid);
+    process.base_address = find_base_address(NULL);
+    process.dll_address = process.base_address;
 
     return 0;
 }

--- a/src/lasr/functions/process.h
+++ b/src/lasr/functions/process.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <lua.h>
+#include <sys/types.h>
 
+pid_t find_process_by_name(const char* proc_name, int fl);
 int find_process_id(lua_State* L);
-int find_cmdline_id(lua_State* L);

--- a/src/lasr/functions/timerControl.c
+++ b/src/lasr/functions/timerControl.c
@@ -1,0 +1,32 @@
+#include "timerControl.h"
+
+#include "../utils.h"
+#include <stdatomic.h>
+
+extern atomic_bool run_running;
+
+/**
+ * Sets run_running to false.
+ *
+ * @param L The lua stack
+ *
+ * @return Always 1.
+ */
+int pauseTimer()
+{
+    atomic_store(&run_running, false);
+    return 1;
+}
+
+/**
+ * Sets run_running to false.
+ *
+ * @param L The lua stack
+ *
+ * @return Always 1.
+ */
+int resumeTimer()
+{
+    atomic_store(&run_running, true);
+    return 1;
+}

--- a/src/lasr/functions/timerControl.h
+++ b/src/lasr/functions/timerControl.h
@@ -1,0 +1,4 @@
+#pragma once
+
+int pauseTimer();
+int resumeTimer();

--- a/src/lasr/utils.c
+++ b/src/lasr/utils.c
@@ -16,15 +16,10 @@ game_process process;
  */
 bool restart_auto_splitter(void)
 {
-    const bool was_asl_enabled = atomic_load(&auto_splitter_enabled);
-    if (was_asl_enabled) {
-        atomic_store(&auto_splitter_enabled, false);
-        while (atomic_load(&auto_splitter_running) && was_asl_enabled) {
-            // wait, this will be very fast so its ok to just spin
-        }
-        atomic_store(&auto_splitter_enabled, true);
-    }
-    return was_asl_enabled;
+    atomic_store(&auto_splitter_running, false);
+    // this should restart in another thread - do not wait here
+    // ref - main:ls_auto_splitter runs lasr:run_auto_splitter which sets atomic
+    return true; // this return value isn't currently used anywhere
 }
 
 /**

--- a/src/lasr/utils.h
+++ b/src/lasr/utils.h
@@ -9,6 +9,7 @@
 #include <unistd.h>
 
 #include <sys/uio.h>
+
 ssize_t process_vm_readv(pid_t pid,
     const struct iovec* local_iov,
     unsigned long liovcnt,
@@ -25,6 +26,8 @@ typedef struct game_process {
     int sort_fl; /*!< First or last PID for multi-process. 0 default is first, 1 is last */
     uintptr_t base_address; /*!< The detected base address of the process */
     uintptr_t dll_address; /*!< The detected base address of the last requested module */
+    char mono_ignore_names[2048]; /*!< Single memory block of process names to ignore searching for */
+    char* ignore_names[100]; /*!< Pointers of each name inside mono_ignore_list, ends in 0 */
 } game_process;
 extern game_process process;
 

--- a/src/lasr/utils.h
+++ b/src/lasr/utils.h
@@ -20,8 +20,9 @@ ssize_t process_vm_readv(pid_t pid,
  * \struct game_process The game process read by the Auto Splitter
  */
 typedef struct game_process {
-    const char* name; /*!< The name of the process */
-    unsigned int pid; /*!< The PID of the process */
+    char* name; /*!< The name of the process */
+    pid_t pid; /*!< The PID of the process */
+    int sort_fl; /*!< First or last PID for multi-process. 0 default is first, 1 is last */
     uintptr_t base_address; /*!< The detected base address of the process */
     uintptr_t dll_address; /*!< The detected base address of the last requested module */
 } game_process;

--- a/src/main.c
+++ b/src/main.c
@@ -78,7 +78,6 @@ static void* ls_auto_splitter(void* arg)
     prctl(PR_SET_NAME, "LS LASR", 0, 0, 0);
     while (1) {
         if (atomic_load(&auto_splitter_enabled) && auto_splitter_file[0] != '\0') {
-            atomic_store(&auto_splitter_running, true);
             run_auto_splitter();
         }
         atomic_store(&auto_splitter_running, false);


### PR DESCRIPTION
part of #315 and #364

- Adds `game_init`, `game_stop` and `script_stop` functions to hook on inside lua autosplitters.
- Rework autosplitter to be while-in-while and continually run the lua script, which enables the added functions to work.
- Rework `process` command to crawl /proc. Not everything has `pgrep` and calling scripted out commands is prone to issues.
- Changed some logic for loading/running atomics.
- docs

Wasn't super keen on is requiring running `Process(name)` in the `game_stop` function. Last commit adds "reset" functionality to the `game_stop` and if not reset C code will loop for the last `process.name` and a `process.sort_fl` for the last process sort. Can squash that or leave it separate, seems better than manually calling `Process()`.