### PR TITLE
musl compatability

### DIFF
--- a/src/lasr/maps/maps.c
+++ b/src/lasr/maps/maps.c
@@ -130,7 +130,14 @@ static bool maps_ioctlSupported(void)
     q.query_flags = PROCMAP_QUERY_COVERING_OR_NEXT_VMA;
     q.query_addr = 0;
 
-    int ret = ioctl(f, PROCMAP_QUERY, &q);
+    // https://man7.org/linux/man-pages/man2/ioctl.2.html
+    // musl uses int instead of uint like glibc
+    int ret = ioctl(f,
+#ifndef __GLIBC__
+        (int)
+#endif
+            PROCMAP_QUERY,
+        &q);
     close(f);
     return ret >= 0;
 }
@@ -158,7 +165,12 @@ static size_t maps_getAll_ioctl(void)
         for (;;) {
             q.vma_name_addr = (uintptr_t)map_name;
             q.vma_name_size = sizeof(map_name);
-            int ret = ioctl(f, PROCMAP_QUERY, &q);
+            int ret = ioctl(f,
+#ifndef __GLIBC__
+                (int)
+#endif
+                    PROCMAP_QUERY,
+                &q);
             if (ret < 0) {
                 break;
             }

--- a/src/lasr/utils.h
+++ b/src/lasr/utils.h
@@ -5,6 +5,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <sys/time.h>
+#include <unistd.h>
 
 #include <sys/uio.h>
 ssize_t process_vm_readv(pid_t pid,

--- a/src/logging.c
+++ b/src/logging.c
@@ -8,7 +8,6 @@
 #include "settings/utils.h"
 
 #include <linux/limits.h>
-#include <linux/prctl.h>
 #include <pthread.h>
 #include <stdarg.h>
 #include <stdatomic.h>

--- a/src/settings/utils.c
+++ b/src/settings/utils.c
@@ -18,7 +18,7 @@
  * @param permissions The attributes used to create the directories.
  */
 // I have no idea how this works
-static void mkdir_p(const char* dir, __mode_t permissions)
+static void mkdir_p(const char* dir, mode_t permissions)
 {
     char tmp[256] = { 0 };
     char* p = NULL;


### PR DESCRIPTION
- __mode_t is not typedefd for musl, should just be mode_t on glibc
- headers required, or duplicated in the case of musl
- ioctl 2nd arg is int vs uint

For void musl and alpine, though I doubt a lot of people are running games on musl.

The __mode_t doesn't seem needed. But also saw the code was from stackoverflow with a comment so lmk if it was for something specific. Didn't notice anything break but also don't think it made directories.