### PR TITLE
readAddress: fix alloc and newlines

### DIFF
--- a/src/lasr/functions/readAddress.c
+++ b/src/lasr/functions/readAddress.c
@@ -64,7 +64,7 @@ READ_MEMORY_FUNCTION(bool)
  */
 char* read_memory_string(uint64_t mem_address, int buffer_size, int32_t* err)
 {
-    char* buffer = (char*)malloc(buffer_size);
+    char* buffer = (char*)calloc(buffer_size + 1, sizeof(char));
     if (buffer == NULL) {
         // Handle memory allocation failure
         return NULL;
@@ -186,8 +186,8 @@ int readAddress(lua_State* L)
         lua_pushboolean(L, value ? 1 : 0);
     } else if (strstr(value_type, "string") != NULL) {
         int buffer_size = atoi(value_type + 6);
-        if (buffer_size < 2) {
-            printf("[readAddress] Invalid string size, please read documentation");
+        if (buffer_size < 2 || buffer_size > 10000) {
+            printf("[readAddress] Invalid string size, please read documentation.\n");
             exit(1);
         }
         char* value = read_memory_string(address, buffer_size, &error);
@@ -196,7 +196,7 @@ int readAddress(lua_State* L)
     } else if (strstr(value_type, "byte")) {
         int array_size = atoi(value_type + 4);
         if (array_size < 1) {
-            printf("[readAddress] Invalid byte array size, please read documentation");
+            printf("[readAddress] Invalid byte array size, please read documentation.\n");
             exit(1);
         }
         uint8_t* results = malloc(array_size * sizeof(uint8_t));


### PR DESCRIPTION
- malloc was causing buffer overflows into other strings, switch to calloc. also +1 the size and make sure it's null terminated.

"Waiting for Fallout3.exe" turned into "Waiting for Fallout30" or "Fallout3h".

<img width="687" height="723" alt="flub" src="https://github.com/user-attachments/assets/2f2e5362-7849-41eb-a90e-1da57add4ac3" />

- added newlines to the failure/exit messages, as uxrvt was a bit garbled and all I read was a partial 'umentation'.

- added a 10k limit size to the string size parsing. if you just type "string" then the next argument (usually a large address) gets used as a string to `atoi()` causing a segfault. could probably add a better safeguard but that should catch a good bit of bad size args.