### PR TITLE
getBaseAddress and getModulsize: consistencies

### DIFF
--- a/src/lasr/functions/getBaseAddress.c
+++ b/src/lasr/functions/getBaseAddress.c
@@ -30,13 +30,12 @@ int getBaseAddress(lua_State* L)
         return 1;
     }
 
-    // Module name passed, search for its base address
     ProcessMap map;
-    bool found = maps_findMapByName(module_name, &map);
-    if (found) {
-        lua_pushnumber(L, map.start);
+    if (maps_findMapByName(module_name, &map)) {
+        lua_pushinteger(L, (lua_Integer)map.start);
         return 1;
     }
-    printf("[getBaseAddress] Cannot search for base address: module name must be a string or nil (for main module)");
-    return 0;
+    lua_pushnil(L);
+    printf("[getBaseAddress] Cannot find module with name \"%s\"\n", module_name);
+    return 1;
 }

--- a/src/lasr/functions/getModuleSize.c
+++ b/src/lasr/functions/getModuleSize.c
@@ -1,19 +1,18 @@
 #include "getModuleSize.h"
 
+#include "../maps/maps.h"
 #include "../utils.h"
-#include "src/lasr/maps/maps.h"
 
-#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
 /**
- * The lua getModuleSize() function.
+ * The Lua getModuleSize() function.
  *
  * FIXME: Size is taken as an unsigned long, which may
  *    ^   exceed the size of lua_Integer
  *
- * @param L The lua state
+ * @param L The Lua state
  */
 int getModuleSize(lua_State* L)
 {
@@ -32,12 +31,11 @@ int getModuleSize(lua_State* L)
     }
 
     ProcessMap map;
-    const bool found = maps_findMapByName(module_name, &map);
-    if (found) {
+    if (maps_findMapByName(module_name, &map)) {
         lua_pushinteger(L, (lua_Integer)map.size);
         return 1;
     }
     lua_pushnil(L);
-    printf("[getModuleSize] Cannot find module with name \"%s\"", module_name);
+    printf("[getModuleSize] Cannot find module with name \"%s\"\n", module_name);
     return 1;
 }


### PR DESCRIPTION
Was trying to use these but had to poke around, didn't see docs.

Seem like the same thing. Mostly a non-change.

- getBaseAddress had `lua_pushnumber` vs `lua_pushinteger` in getModuleSize
- the error message at the end of getBaseAddress made it seem like the args were wrong
- ret values were different. i'm not sure they're used anyways, unless it's in lua maybe.
- const var seemed unneed, and var 'found' isn't used anyway
- there is a `lua_pushnil` in getModuleSize that getBaseAddress doesn't have, assume it's needed
- getModuleSize doesn't seem to use stdint.h