### PR TITLE
musl: define _GNU_SOURCES for strcasestr, types.h not time.h

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,7 @@ project(
 )
 
 add_project_arguments('-DAPP_VERSION="@0@"'.format(meson.project_version()), language: 'c')
+add_project_arguments('-D_GNU_SOURCE=1 ', language: 'c')
 
 if get_option('buildtype') == 'debug'
     add_project_arguments('-DDEBUG', language: 'c')

--- a/src/lasr/utils.h
+++ b/src/lasr/utils.h
@@ -5,7 +5,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <sys/time.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include <sys/uio.h>


### PR DESCRIPTION
- [2844e7a](https://github.com/LibreSplit/LibreSplit/commit/2844e7ae253c28f396631a7f40fb5a446b30f51a) for case in-sensitive compares it was suggested to use `strcasestr`, ~~however it is not building with musl for me, also the compiler complains about the previous use of NULL~~. for reference https://github.com/esmil/musl/blob/master/src/string/strncasecmp.c --- requires `_GNU_SOURCE` defined
- [aeeaf0c](https://github.com/LibreSplit/LibreSplit/commit/ad421ca1c0cc3b7073cf551bbcaed17aeeaf0cdc#diff-5e79e5a1392b48a170f99f0da623e213609706ac07575b1472dd3c99e5cd2ea9) i somehow made a a typo for time vs types