### PR TITLE
feat(lasr): Use LuaJIT 64-bit FFI types to represent addresses.

### DIFF
--- a/docs/auto-splitters.md
+++ b/docs/auto-splitters.md
@@ -358,6 +358,13 @@ end
 
         * Cheat Engine is a tool that allows you to easily find Addresses and Pointer Paths for those Addresses, so you don't need to debug the game to figure out the structure of the memory.
 
+    * Lua's default `'number'` type cannot accurately represent some very large addresses. If you need
+      to pass values greater than `2^53 - 1` (`0x001F_FFFF_FFFF_FFFF`), you should use LuaJIT's 64-bit
+      [FFI integers](https://luajit.org/ext_ffi_api.html#literals) through the `LL` suffix:
+      ```lua
+      local far_away = readAddress('uint', 0x0020000000000000LL)
+      ```
+
 ## sig_scan
 
 `sig_scan` performs a signature/pattern scan using the provided IDA-style byte array and an integer offset, It returns a numeric representation of the found address.
@@ -368,9 +375,9 @@ Example:
 
 Returns:
 
-`5387832857`
+`5387832857LL`
 
-(Which is the decimal representation of the address `0x14123ce19`)
+(Which is the decimal representation of the address `0x14123ce19LL`)
 
 ### Notes
 
@@ -500,15 +507,15 @@ The array will have a structure similar to this:
 {
     {
         name="something",
-        start=123456,
-        end=789456,
-        size=666000
+        start=123456ULL,
+        end=789456ULL,
+        size=666000ULL
     },
     {
         name="something_else",
-        start=123456,
-        end=789456,
-        size=666000
+        start=123456ULL,
+        end=789456ULL,
+        size=666000ULL
     }
 }
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,12 +39,12 @@ Here, `readAddress()` throws an error because it cannot distinguish between the 
 `0x0020000000000000` (`2^53`) and `0x0020000000000001` (`2^53 + 1`) as floating-point values. By
 passing 64-bit integers with the `LL` suffix, we can represent all possible addresses.
 
-### `bad argument #1 to 'abs' (number expected, got cdata)`
+### `bad argument #1 to '<function>' (number expected, got cdata)`
 For reasons described in the previous section, many auto splitter functions (`sizeOf()`,
 `readAddress('long', ...)`, etc.) return 64-bit [FFI integers](https://luajit.org/ext_ffi_api.html#literals)
 rather than regular (floating-point) `'number'`s. These values have a `type()` of `'cdata'` and
-cannot be passed directly to most Lua standard library functions. Pass them first to `tonumber()`,
-but be aware that this may result in rounding if the input is larger than `2^53`.
+cannot be passed directly to most Lua standard library functions. Pass them first through
+`tonumber()`, but be aware that this may result in rounding if the input is larger than `2^53`.
 
 ```lua
 local index = readAddress('ulong', 0x1234)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,3 +17,40 @@
 ## Memory offsets are wrong/dont work
 * This might be to some bug in fetching maps with ioctl
 * You can disable ioctl behaviour by setting `LIBRESPLIT_DISABLE_IOCTL_MAPS` environment variable to `1`.
+
+## Auto splitter errors
+
+### `ERROR: Floating-point argument is too large to represent a valid integer`
+Lua `'number'`s are 64-bit floating-point values, and thus cannot represent all possible 64-bit
+addresses. Values larger than `2^53` are rounded to the nearest multiple of some power of two,
+wreaking havoc on memory reads and bitwise operations. For this reason, you must use 64-bit
+[FFI integers](https://luajit.org/ext_ffi_api.html#literals) to pass large values to functions:
+```lua
+print(2^53 == 2^53 + 1)      --> true
+print(2LL^53 == 2LL^53 + 1)  --> false
+
+local far_away = readAddress('uint', 0x0020000000000000)
+    --> [readAddress] ERROR: Floating-point argument is too large to represent a valid integer. Please write 0x20000000000000LL instead of 0x20000000000000. Check your autosplitter code.
+    --> far_away == nil
+local far_away = readAddress('uint', 0x0020000000000000LL)
+    --> OK
+```
+Here, `readAddress()` throws an error because it cannot distinguish between the addresses
+`0x0020000000000000` (`2^53`) and `0x0020000000000001` (`2^53 + 1`) as floating-point values. By
+passing 64-bit integers with the `LL` suffix, we can represent all possible addresses.
+
+### `bad argument #1 to 'abs' (number expected, got cdata)`
+For reasons described in the previous section, many auto splitter functions (`sizeOf()`,
+`readAddress('long', ...)`, etc.) return 64-bit [FFI integers](https://luajit.org/ext_ffi_api.html#literals)
+rather than regular (floating-point) `'number'`s. These values have a `type()` of `'cdata'` and
+cannot be passed directly to most Lua standard library functions. Pass them first to `tonumber()`,
+but be aware that this may result in rounding if the input is larger than `2^53`.
+
+```lua
+local index = readAddress('ulong', 0x1234)
+print(index)  --> '10ULL'
+local substring = buffer:sub(index)
+    --> bad argument #1 to 'sub' (number expected, got cdata)
+local substring = buffer:sub(tonumber(index))
+    --> OK
+```

--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,7 @@ libresplit_sources = files(
     # LASR
     'src/lasr/auto-splitter.c',
     'src/lasr/utils.c',
+    'src/lasr/int64.c',
     'src/lasr/maps/maps.c',
     'src/lasr/functions/bitwise.c',
     'src/lasr/functions/getBaseAddress.c',

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -137,6 +137,7 @@ void push_lasr_functions(lua_State* L, const lasr_function* functions)
     }
 }
 
+#ifndef DEBUG
 /**
  * Override of the standard openlibs functions to open only a subset
  * of libraries in the Lua Runtime.
@@ -152,6 +153,7 @@ LUALIB_API void luaL_openlibs(lua_State* L)
         lua_call(L, 1, 0);
     }
 }
+#endif
 
 /**
  * Disables possibly dangerous functions in the Lua Runtime.
@@ -452,9 +454,13 @@ void gameTime(lua_State* L)
  */
 void run_auto_splitter(void)
 {
+    (void)disabled_functions;
+    (void)lj_lib_load;
     lua_State* L = luaL_newstate();
     luaL_openlibs(L);
+#ifndef DEBUG
     disable_functions(L, disabled_functions);
+#endif
     push_lasr_functions(L, luac_functions);
     setup_int64_overloads(L);
 

--- a/src/lasr/auto-splitter.c
+++ b/src/lasr/auto-splitter.c
@@ -6,6 +6,7 @@
 
 #include "./maps/maps.h"
 #include "functions.h"
+#include "int64.h"
 #include "utils.h"
 
 #include <lauxlib.h>
@@ -455,6 +456,7 @@ void run_auto_splitter(void)
     luaL_openlibs(L);
     disable_functions(L, disabled_functions);
     push_lasr_functions(L, luac_functions);
+    setup_int64_overloads(L);
 
     char current_file[PATH_MAX];
     strcpy(current_file, auto_splitter_file);

--- a/src/lasr/functions/bitwise.c
+++ b/src/lasr/functions/bitwise.c
@@ -1,4 +1,5 @@
 #include "bitwise.h"
+#include "src/lasr/int64.h"
 
 #include <stdio.h>
 
@@ -15,18 +16,21 @@ int b_and(lua_State* L)
         return 0;
     }
 
-    if (!lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
+    if (!LUA_ISADDRESS_PRINT(L, 1) || !LUA_ISADDRESS_PRINT(L, 2)) {
         // Arguments are not numbers
         printf("[b_and] Both arguments must be integers");
         return 0;
     }
 
-    lua_Integer a = lua_tointeger(L, 1);
-    lua_Integer b = lua_tointeger(L, 2);
+    uint64_t a = lua_toaddress(L, 1);
+    uint64_t b = lua_toaddress(L, 2);
 
-    lua_Integer result = a & b;
+    uint64_t result = a & b;
 
-    lua_pushinteger(L, result);
+    if (lua_isnumber(L, 1) && lua_isnumber(L, 2) && result <= LUA_FLOAT_ADDRESS_MAX)
+        lua_pushinteger(L, result);
+    else
+        lua_pushuint64(L, result);
     return 1;
 }
 
@@ -43,18 +47,20 @@ int b_or(lua_State* L)
         return 0;
     }
 
-    if (!lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
+    if (!LUA_ISADDRESS_PRINT(L, 1) || !LUA_ISADDRESS_PRINT(L, 2)) {
         // Arguments are not numbers
-        printf("[b_or] Both arguments must be integers");
         return 0;
     }
 
-    lua_Integer a = lua_tointeger(L, 1);
-    lua_Integer b = lua_tointeger(L, 2);
+    uint64_t a = lua_toaddress(L, 1);
+    uint64_t b = lua_toaddress(L, 2);
 
-    lua_Integer result = a | b;
+    uint64_t result = a | b;
 
-    lua_pushinteger(L, result);
+    if (lua_isnumber(L, 1) && lua_isnumber(L, 2) && result <= LUA_FLOAT_ADDRESS_MAX)
+        lua_pushinteger(L, result);
+    else
+        lua_pushuint64(L, result);
     return 1;
 }
 
@@ -71,18 +77,20 @@ int b_xor(lua_State* L)
         return 0;
     }
 
-    if (!lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
+    if (!LUA_ISADDRESS_PRINT(L, 1) || !LUA_ISADDRESS_PRINT(L, 2)) {
         // Arguments are not numbers
-        printf("[b_xor] Both arguments must be integers");
         return 0;
     }
 
-    lua_Integer a = lua_tointeger(L, 1);
-    lua_Integer b = lua_tointeger(L, 2);
+    uint64_t a = lua_toaddress(L, 1);
+    uint64_t b = lua_toaddress(L, 2);
 
-    lua_Integer result = a ^ b;
+    uint64_t result = a ^ b;
 
-    lua_pushinteger(L, result);
+    if (lua_isnumber(L, 1) && lua_isnumber(L, 2) && result <= LUA_FLOAT_ADDRESS_MAX)
+        lua_pushinteger(L, result);
+    else
+        lua_pushuint64(L, result);
     return 1;
 }
 
@@ -99,17 +107,19 @@ int b_not(lua_State* L)
         return 0;
     }
 
-    if (!lua_isnumber(L, 1)) {
+    if (!LUA_ISADDRESS_PRINT(L, 1)) {
         // Argument is not number
-        printf("[b_not] The argument must be an integer");
         return 0;
     }
 
-    lua_Integer a = lua_tointeger(L, 1);
+    uint64_t a = lua_toaddress(L, 1);
 
-    lua_Integer result = ~a;
+    uint64_t result = ~a;
 
-    lua_pushinteger(L, result);
+    if (lua_isnumber(L, 1) && result <= LUA_FLOAT_ADDRESS_MAX)
+        lua_pushinteger(L, result);
+    else
+        lua_pushuint64(L, result);
     return 1;
 }
 
@@ -126,18 +136,20 @@ int b_lshift(lua_State* L)
         return 0;
     }
 
-    if (!lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
+    if (!LUA_ISADDRESS_PRINT(L, 1) || !LUA_ISADDRESS_PRINT(L, 2)) {
         // Arguments are not numbers
-        printf("[b_lshift] Both arguments must be integers");
         return 0;
     }
 
-    lua_Integer a = lua_tointeger(L, 1);
-    lua_Integer b = lua_tointeger(L, 2);
+    uint64_t a = lua_toaddress(L, 1);
+    uint64_t b = lua_toaddress(L, 2);
 
-    lua_Integer result = a << b;
+    uint64_t result = a << b;
 
-    lua_pushinteger(L, result);
+    if (lua_isnumber(L, 1) && lua_isnumber(L, 2) && result <= LUA_FLOAT_ADDRESS_MAX)
+        lua_pushinteger(L, result);
+    else
+        lua_pushuint64(L, result);
     return 1;
 }
 
@@ -154,17 +166,19 @@ int b_rshift(lua_State* L)
         return 0;
     }
 
-    if (!lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
+    if (!LUA_ISADDRESS_PRINT(L, 2) || !LUA_ISADDRESS_PRINT(L, 1)) {
         // Arguments are not numbers
-        printf("[b_rshift] Both arguments must be integers");
         return 0;
     }
 
-    lua_Integer a = lua_tointeger(L, 1);
-    lua_Integer b = lua_tointeger(L, 2);
+    uint64_t a = lua_toaddress(L, 1);
+    uint64_t b = lua_toaddress(L, 2);
 
-    lua_Integer result = a >> b;
+    uint64_t result = a >> b;
 
-    lua_pushinteger(L, result);
+    if (lua_isnumber(L, 1) && lua_isnumber(L, 2) && result <= LUA_FLOAT_ADDRESS_MAX)
+        lua_pushinteger(L, result);
+    else
+        lua_pushuint64(L, result);
     return 1;
 }

--- a/src/lasr/functions/getBaseAddress.c
+++ b/src/lasr/functions/getBaseAddress.c
@@ -1,5 +1,6 @@
 #include "getBaseAddress.h"
 
+#include "../int64.h"
 #include "../maps/maps.h"
 #include "../utils.h"
 
@@ -32,7 +33,7 @@ int getBaseAddress(lua_State* L)
 
     ProcessMap map;
     if (maps_findMapByName(module_name, &map)) {
-        lua_pushinteger(L, (lua_Integer)map.start);
+        lua_pushuint64(L, map.start);
         return 1;
     }
     lua_pushnil(L);

--- a/src/lasr/functions/getMaps.c
+++ b/src/lasr/functions/getMaps.c
@@ -1,5 +1,6 @@
 #include "getMaps.h"
 
+#include "../int64.h"
 #include "../maps/maps.h"
 
 #include <stdio.h>
@@ -34,15 +35,15 @@ int getMaps(lua_State* L)
         lua_setfield(L, -2, "name");
         // Stack: array, table
         // Push "start"
-        lua_pushnumber(L, map.start);
+        lua_pushuint64(L, map.start);
         // Stack: array, table, value
         lua_setfield(L, -2, "start");
         // Stack: array, table
         // Push "end"
-        lua_pushnumber(L, map.end);
+        lua_pushuint64(L, map.end);
         lua_setfield(L, -2, "end");
         // Push "size"
-        lua_pushnumber(L, map.size);
+        lua_pushuint64(L, map.size);
         lua_setfield(L, -2, "size");
 
         // Stack: Array, Table, [TopOfStack]

--- a/src/lasr/functions/getModuleSize.c
+++ b/src/lasr/functions/getModuleSize.c
@@ -1,5 +1,6 @@
 #include "getModuleSize.h"
 
+#include "../int64.h"
 #include "../maps/maps.h"
 #include "../utils.h"
 
@@ -32,7 +33,7 @@ int getModuleSize(lua_State* L)
 
     ProcessMap map;
     if (maps_findMapByName(module_name, &map)) {
-        lua_pushinteger(L, (lua_Integer)map.size);
+        lua_pushuint64(L, (lua_Integer)map.size);
         return 1;
     }
     lua_pushnil(L);

--- a/src/lasr/functions/readAddress.c
+++ b/src/lasr/functions/readAddress.c
@@ -1,8 +1,12 @@
 #include "readAddress.h"
+#include "../int64.h"
 #include "../utils.h"
 
-#include <errno.h>
+#include <lauxlib.h>
 #include <lua.h>
+
+#include <assert.h>
+#include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -122,23 +126,31 @@ int readAddress(lua_State* L)
         return 1;
     }
 
-    if (lua_isnumber(L, 2)) {
-        address = process.base_address + lua_tointeger(L, 2);
+    if (LUA_ISADDRESS_PRINT(L, 2)) {
+        address = process.base_address + lua_toaddress(L, 2);
         i = 3;
-    } else {
+    } else if (lua_isstring(L, 2)) {
         const char* module = lua_tostring(L, 2);
         if (strcmp(process.name, module) != 0) {
             process.dll_address = find_base_address(module);
         }
-        address = process.dll_address + lua_tointeger(L, 3);
+        if (!LUA_ISADDRESS_PRINT(L, 3)) {
+            lua_pushnil(L);
+            return 1;
+        }
+        address = process.dll_address + lua_toaddress(L, 3);
         i = 4;
+    } else {
+        printf("[readAddress] The second argument must be either a module name or a base address. Check your autosplitter code.\n");
+        lua_pushnil(L);
+        return 1;
     }
 
     int error = 0;
 
     for (; i <= lua_gettop(L); i++) {
         if (address <= UINT32_MAX) {
-            address = read_memory_uint32_t((uint64_t)address, &error);
+            address = read_memory_uint32_t(address, &error);
             if (memory_error)
                 break;
         } else {
@@ -146,7 +158,11 @@ int readAddress(lua_State* L)
             if (memory_error)
                 break;
         }
-        address += lua_tointeger(L, i);
+        if (!LUA_ISADDRESS_PRINT(L, i)) {
+            lua_pushnil(L);
+            return 1;
+        }
+        address += lua_toaddress(L, i);
     }
 
     if (strcmp(value_type, "sbyte") == 0) {
@@ -168,13 +184,11 @@ int readAddress(lua_State* L)
         uint32_t value = read_memory_uint32_t(address, &error);
         lua_pushinteger(L, value);
     } else if (strcmp(value_type, "long") == 0) {
-        // TODO: Fix 64 bit numbers, luajit 5.1 doesnt support 64 bit numbers natively
         int64_t value = read_memory_int64_t(address, &error);
-        lua_pushinteger(L, value);
+        lua_pushsint64(L, value);
     } else if (strcmp(value_type, "ulong") == 0) {
-        // TODO: Fix 64 bit numbers, luajit 5.1 doesnt support 64 bit numbers natively
         uint64_t value = read_memory_uint64_t(address, &error);
-        lua_pushinteger(L, value);
+        lua_pushuint64(L, value);
     } else if (strcmp(value_type, "float") == 0) {
         float value = read_memory_float(address, &error);
         lua_pushnumber(L, value);

--- a/src/lasr/functions/signature.c
+++ b/src/lasr/functions/signature.c
@@ -1,5 +1,6 @@
 #include "signature.h"
 
+#include "../int64.h"
 #include "../utils.h"
 
 #include <fcntl.h>
@@ -192,7 +193,7 @@ int perform_sig_scan(lua_State* L)
         return 1;
     }
 
-    if (!lua_isstring(L, 1) || !lua_isnumber(L, 2)) {
+    if (!lua_isstring(L, 1) || !LUA_ISADDRESS_PRINT(L, 2)) {
         log_error("Invalid argument types: expected (string, number)");
         lua_pushnil(L);
         return 1;
@@ -200,7 +201,7 @@ int perform_sig_scan(lua_State* L)
 
     pid_t p_pid = process.pid;
     const char* signature = lua_tostring(L, 1);
-    intptr_t offset = lua_tointeger(L, 2);
+    intptr_t offset = lua_toaddress(L, 2);
 
     // Validate signature string
     if (strlen(signature) == 0) {
@@ -258,7 +259,7 @@ int perform_sig_scan(lua_State* L)
                 free(pattern);
                 free(regions);
 
-                lua_pushnumber(L, result);
+                lua_pushsint64(L, result);
                 return 1;
             }
         }

--- a/src/lasr/functions/sizeOf.c
+++ b/src/lasr/functions/sizeOf.c
@@ -1,4 +1,5 @@
 #include "sizeOf.h"
+#include "../int64.h"
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -63,6 +64,6 @@ int size_of(lua_State* L)
         lua_pushnil(L);
         return 1;
     }
-    lua_pushinteger(L, size_of_type);
+    lua_pushuint64(L, size_of_type);
     return 1;
 }

--- a/src/lasr/int64.c
+++ b/src/lasr/int64.c
@@ -12,10 +12,12 @@
  * for integer literals syntax (`42LL`, `0xffULL`). These values have a `type()` of `"cdata"` and a
  * `lua_type()` value of #LUA_TCDATA (10). They natively support arithmetic and comparisons with
  * standard Lua `number`s as well as being passed to `tostring()`, `print()`, `string.format()` and
- * the `bit.*` functions, but cannot be concatenated with `..`.
+ * the `bit.*` functions, but cannot be concatenated with `..`. We add support for string
+ * concatenation in setup_int64_overloads().
  */
 
 #include "int64.h"
+#include "utils.h"
 
 #include <lauxlib.h>
 #include <lua.h>
@@ -23,6 +25,8 @@
 #include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
 /**
  * @brief Determine whether a value on the Lua stack represents a LuaJIT 64-bit integer.
@@ -157,4 +161,60 @@ uintptr_t lua_toaddress(lua_State* L, int idx)
         return lua_toint64(L, idx);
     uintptr_t addr = lua_tonumber(L, idx);
     return addr;
+}
+
+/**
+ * @brief Alternative implementation of Lua's concatenation (`..`) operator; see
+ * setup_int64_overloads() for more details.
+ *
+ * Takes two arguments `x` and `y` of type `string | number | int64` from the Lua stack and returns
+ * a single string representing `x .. y`.
+ *
+ * @param L The Lua state
+ */
+static int int64_concat_metamethod(lua_State* L)
+{
+    assert(lua_gettop(L) == 2);
+    for (int i = 1; i <= 2; i++) {
+        if (!lua_isnumber(L, i) && !lua_isstring(L, i) && !lua_isint64(L, i)) {
+            char* error;
+            int status = asprintf(&error, "attempt to concatenate '%s' and '%s'", lua_typename(L, 1), lua_typename(L, 2));
+            if (status == -1) {
+                perror("Failed to generate error message");
+                exit(EXIT_FAILURE);
+            }
+            lua_pushstring(L, error);
+            free(error);
+            lua_error(L);
+        }
+    }
+    stringify(L, 1);
+    stringify(L, 2);
+    lua_concat(L, 2);
+    assert(lua_gettop(L) == 1);
+    return 1;
+}
+
+/**
+ * @brief Integrate FFI integers with Lua operators such as string concatenation.
+ *
+ * Lua actually allows you to set metatables on primitive types like `number`, `string` and
+ * `cdata`, but only from the C API. (See [§2.8 of the Lua manual](https://www.lua.org/manual/5.1/manual.html#2.8).)
+ * The metatable applies to _all_ instances of the type, so metamethods can be used to change the
+ * implementation for operators like `..` or `tostring()`. This method sets a metatable on `cdata`
+ * values, overriding the `__concat` metamethod to support concatenation with FFI integers.
+ *
+ * @param L The Lua state.
+ */
+void setup_int64_overloads(lua_State* L)
+{
+    int initial_top = lua_gettop(L);
+    lua_pushsint64(L, 0);
+    if (!lua_getmetatable(L, -1))
+        lua_createtable(L, 0, 1);
+    lua_pushcfunction(L, int64_concat_metamethod);
+    lua_setfield(L, -2, "__concat");
+    lua_setmetatable(L, -2); // this sets the metatable on _all_ values of type `cdata`, not just the target one.
+    lua_pop(L, 1);
+    assert(lua_gettop(L) == initial_top);
 }

--- a/src/lasr/int64.c
+++ b/src/lasr/int64.c
@@ -1,0 +1,160 @@
+/**
+ * @file int64.c
+ * @brief Convenience functions for using LuaJIT's FFI types for 64-bit integer support.
+ *
+ * Due to the way floating-point numbers work, (see [here](https://w.wiki/5xCp) for details)
+ * `double`s with values of 2**53 and above will be rounded to the nearest multiple of some power of
+ * two, so they cannot reliably be used as offsets into a 64-bit address space. This is the cause of
+ * [issue 308](https://github.com/LibreSplit/LibreSplit/issues/308), making it impossible to read
+ * data placed at large addresses.
+ *
+ * LuaJIT supports 64-bit signed and unsigned types as part of its FFI support, with a custom syntax
+ * for integer literals syntax (`42LL`, `0xffULL`). These values have a `type()` of `"cdata"` and a
+ * `lua_type()` value of #LUA_TCDATA (10). They natively support arithmetic and comparisons with
+ * standard Lua `number`s as well as being passed to `tostring()`, `print()`, `string.format()` and
+ * the `bit.*` functions, but cannot be concatenated with `..`.
+ */
+
+#include "int64.h"
+
+#include <lauxlib.h>
+#include <lua.h>
+
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * @brief Determine whether a value on the Lua stack represents a LuaJIT 64-bit integer.
+ *
+ * Cannot distinguish integers from other `cdata` types created by the Lua `ffi` library. This is
+ * fine as scripts can't currently create other FFI types (except `complex` with the `I` suffix but
+ * that's 16 bytes), but if in future they can we should insert a check equivalent to the following Lua
+ * code to avoid an out-of-bounds read in lua_toint64().
+ * ```lua
+ * local ffi = require('ffi')
+ * assert(ffi.typeof(v) == 'ctype<int64_t>' || ffi.typeof(v) == 'ctype<uint64_t>')
+ * ```
+ *
+ * @param L The Lua state.
+ * @param idx An index into the Lua stack.
+ * @return True if the stack element at `idx` is a `<int>LL` or `<int>ULL` integer.
+ */
+bool lua_isint64(lua_State* L, int idx)
+{
+    return lua_type(L, idx) == LUA_TCDATA;
+}
+
+/**
+ * @brief Fetch a LuaJIT 64-bit integer from the stack.
+ * @param L The Lua state.
+ * @param idx An index into the Lua stack;
+ * @return The 64-bit integer at `idx`, or `0` in the event of an error.
+ */
+uint64_t lua_toint64(lua_State* L, int idx)
+{
+    uint64_t* p = (uint64_t*)lua_topointer(L, idx);
+    if (!lua_isint64(L, idx) || !p)
+        return 0;
+
+    // XXX: This may read out-of-bounds if the `cdata` item at `idx` is smaller than 8 bytes.
+    // This is not possible presently, as without the `ffi` module the only way to produce a `cdata`
+    // value is with the `<int>LL`, `<int>ULL` or `<float>I` syntax.
+    return *p;
+}
+
+/**
+ * @brief Push a value to the Lua stack as a LuaJIT FFI 64-bit signed integer.
+ * @param L The Lua state.
+ * @param n A 64-bit integer.
+ */
+void lua_pushsint64(lua_State* L, int64_t n)
+{
+    char code[28]; // strlen("return 0xffffffffffffffffLL") + 1
+    snprintf(code, sizeof(code), "return 0x%lxLL", n);
+    (void)luaL_dostring(L, code);
+}
+
+/**
+ * @brief Push a value to the Lua stack as a LuaJIT FFI 64-bit unsigned integer.
+ * @param L The Lua state.
+ * @param n A 64-bit integer.
+ */
+void lua_pushuint64(lua_State* L, uint64_t n)
+{
+    char code[29]; // strlen("return 0xffffffffffffffffULL") + 1
+    snprintf(code, sizeof(code), "return 0x%lxULL", n);
+    (void)luaL_dostring(L, code);
+}
+
+/**
+ * @brief Return whether a Lua value can be interpreted as a 64-bit address.
+ *
+ * Equivalent to invoking lua_isaddress_warn() with a `NULL` value for `function`.
+ *
+ * @param L The Lua state.
+ * @param idx An index into the Lua stack.
+ * @return True if the element in the Lua stack at `idx` represents a LuaJIT 64-bit integer, or a
+ * floating-point number small enough to be converted into one.
+ */
+bool lua_isaddress(lua_State* L, int idx)
+{
+    return lua_isaddress_print(L, idx, NULL);
+}
+
+/**
+ * @brief Return whether a Lua value can be interpreted as a 64-bit address, and print an error if it can't.
+ *
+ * For a more convenient interface, see LUA_ISADDRESS(), which calls this function with the current
+ * function name as an argument. A Lua `number` value is considered an 'address' if it does not
+ * exceed #LUA_FLOAT_ADDRESS_MAX.
+ *
+ * @param L The Lua state.
+ * @param idx An index into the Lua stack.
+ * @param function The name of the current Lua autosplitter function. Used in the error message. If
+ * `NULL`, don't print anything.
+ * @return True if the element in the Lua stack at `idx` represents a LuaJIT 64-bit integer, or a
+ * floating-point number small enough to be converted into one.
+ */
+bool lua_isaddress_print(lua_State* L, int idx, const char* function)
+{
+    if (lua_isint64(L, idx))
+        return true;
+    if (!lua_isnumber(L, idx)) {
+        if (function != NULL)
+            printf("[%s] ERROR: Argument must be numeric. Check your autosplitter code.\n", function);
+        return false;
+    }
+    double addr = lua_tonumber(L, idx);
+    uintptr_t addr_abs = fabs(addr);
+    bool is_valid = fabs(addr) <= LUA_FLOAT_ADDRESS_MAX;
+    if (!is_valid && function != NULL)
+        printf("[%s] ERROR: Floating-point argument is too large to represent a valid integer. "
+               "Please write %s0x%lxLL instead of %s0x%lx. Check your autosplitter code.\n",
+            function,
+            addr < 0 ? "-" : "", addr_abs,
+            addr < 0 ? "-" : "", addr_abs);
+    return is_valid;
+}
+
+/**
+ * @brief Get a value from the Lua for use as an address or file offset.
+ *
+ * If the value is a negative signed value, we cast it into an unsigned integer. This is to
+ * facilitate passing negative offsets as part of pointer paths in readAddress(), which may be
+ * useful for dealing with some structs.
+ *
+ * @param L The Lua state.
+ * @param idx An index into the Lua stack.
+ * @return The value at `idx` as an unsigned integer, or 0 if it is not usable as an address as
+ * determined by lua_isaddress().
+ */
+uintptr_t lua_toaddress(lua_State* L, int idx)
+{
+    if (!lua_isaddress(L, idx))
+        return 0;
+    if (lua_isint64(L, idx))
+        return lua_toint64(L, idx);
+    uintptr_t addr = lua_tonumber(L, idx);
+    return addr;
+}

--- a/src/lasr/int64.h
+++ b/src/lasr/int64.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <lua.h>
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+// Additional Lua types as used by the JIT FFI API.
+// Copied from the LuaJIT's internal `lj_obj.h` header.
+
+/** @brief The maximum type ID defined by standard Lua 5.1. */
+#define LAST_TT LUA_TTHREAD
+/** @brief The type ID for LuaJIT's FFI function prototype objects (`type(x) == 'proto'`). Not used. */
+#define LUA_TPROTO (LAST_TT + 1)
+/** @brief The type ID for LuaJIT's 'cdata' type, used for `LL` and `ULL` literals as well types created by the `ffi` library. */
+#define LUA_TCDATA (LAST_TT + 2)
+
+/**
+ * @brief The largest value of a Lua `number` (`double`) that can be reliably used as an address in 64-bit programs.
+ *
+ * Has the property that `(double)LUA_FLOAT_ADDRESS_MAX != (double)LUA_FLOAT_ADDRESS_MAX + 1` but
+ * `(double)LUA_FLOAT_ADDRESS_MAX + 1 == (double)LUA_FLOAT_ADDRESS_MAX + 2`.
+ */
+#define LUA_FLOAT_ADDRESS_MAX ((1ULL << 53) - 1)
+
+bool lua_isint64(lua_State* L, int idx);
+uint64_t lua_toint64(lua_State* L, int idx);
+void lua_pushsint64(lua_State* L, int64_t n);
+void lua_pushuint64(lua_State* L, uint64_t n);
+
+bool lua_isaddress(lua_State* L, int idx);
+bool lua_isaddress_print(lua_State* L, int idx, const char* function);
+uintptr_t lua_toaddress(lua_State* L, int idx);
+
+/** Convenience macro for invoking `lua_isaddress_print()` passing the current function name. */
+#define LUA_ISADDRESS_PRINT(L, idx) lua_isaddress_print((L), (idx), __func__)

--- a/src/lasr/int64.h
+++ b/src/lasr/int64.h
@@ -33,5 +33,7 @@ bool lua_isaddress(lua_State* L, int idx);
 bool lua_isaddress_print(lua_State* L, int idx, const char* function);
 uintptr_t lua_toaddress(lua_State* L, int idx);
 
+void setup_int64_overloads(lua_State* L);
+
 /** Convenience macro for invoking `lua_isaddress_print()` passing the current function name. */
 #define LUA_ISADDRESS_PRINT(L, idx) lua_isaddress_print((L), (idx), __func__)

--- a/src/lasr/utils.c
+++ b/src/lasr/utils.c
@@ -1,9 +1,12 @@
 #include "utils.h"
 #include "../gui/dialogs.h"
 #include "./auto-splitter.h"
+#include "./int64.h"
 #include "./maps/maps.h"
 
 #include <glib.h>
+#include <lua.h>
+
 #include <stdatomic.h>
 #include <stdio.h>
 
@@ -85,6 +88,30 @@ bool handle_memory_error(uint32_t err)
 }
 
 /**
+ * @brief Convert a Lua value in-place to a string by calling `tostring()`.
+ *
+ * Like `lua_tostring()`, the value at `index` is replaced with a string value if it is not already
+ * a string.
+ *
+ * @param L The Lua state.
+ * @param index An index into the Lua stack.
+ * @return A pointer to a string inside the Lua state.
+ */
+const char* stringify(lua_State* L, int index)
+{
+    int initial_top = lua_gettop(L);
+    if (lua_isstring(L, index) || lua_isnumber(L, index))
+        return lua_tostring(L, index);
+    lua_getglobal(L, "tostring");
+    int new_index = index < 0 ? index - 1 : index;
+    lua_pushvalue(L, new_index);
+    lua_call(L, 1, 1);
+    lua_replace(L, new_index);
+    assert(lua_gettop(L) == initial_top && lua_isstring(L, index));
+    return lua_tostring(L, index);
+}
+
+/**
  * Utility function to convert a lua value to a string.
  *
  * Converts a value to a printable C string according to its type.
@@ -98,6 +125,10 @@ const char* value_to_c_string(lua_State* L, int index)
             return lua_tostring(L, index);
         case LUA_TNUMBER:
             return lua_tostring(L, index);
+        case LUA_TCDATA:
+            if (lua_isint64(L, index))
+                return stringify(L, index);
+            return "??";
         case LUA_TBOOLEAN:
             return lua_toboolean(L, index) ? "true" : "false";
         case LUA_TNIL:

--- a/src/lasr/utils.h
+++ b/src/lasr/utils.h
@@ -37,4 +37,5 @@ typedef struct ProcessMap {
 bool restart_auto_splitter(void);
 uintptr_t find_base_address(const char* module);
 bool handle_memory_error(uint32_t err);
+const char* stringify(lua_State* L, int index);
 const char* value_to_c_string(lua_State* L, int index);

--- a/test.lua
+++ b/test.lua
@@ -1,0 +1,231 @@
+process("libresplit")
+require("busted.runner")()
+local assert = require("luassert")
+local say = require("say")
+
+local function identical(_, arguments)
+	local a = arguments[1]
+	local b = arguments[2]
+	return a == b and type(a) == type(b) and tostring(a) == tostring(b)
+end
+
+local function is_uint64(_, arguments)
+	local a = arguments[1]
+	return type(a) == "cdata" and tostring(a):match("ULL$")
+end
+
+local function is_sint64(_, arguments)
+	local a = arguments[1]
+	return type(a) == "cdata" and tostring(a):match("[^U]LL$")
+end
+
+say:set_namespace("en")
+say:set("assertion.identical.positive", "Expected objects to be identical.\nPassed in:\n%s\nExpected:\n%s")
+say:set("assertion.identical.negative", "Expected objects to not be identical.\nPassed in:\n%s\nDid not expect:\n%s")
+assert:register("assertion", "identical", identical, "assertion.identical.positive", "assertion.identical.negative")
+
+say:set("assertion.uint64.positive", "Expected object to be an unsigned FFI integer.\nPassed in:\n%s\nExpected:\n%s")
+say:set(
+	"assertion.uint64.negative",
+	"Expected object to not be an unsigned FFI integer.\nPassed in:\n%s\nDid not expect:\n%s"
+)
+assert:register("assertion", "uint64", is_uint64, "assertion.uint64.positive", "assertion.uint64.negative")
+
+say:set("assertion.sint64.positive", "Expected object to be a signed FFI integer.\nPassed in:\n%s\nExpected:\n%s")
+say:set(
+	"assertion.sint64.negative",
+	"Expected object to not be a signed FFI integer.\nPassed in:\n%s\nDid not expect:\n%s"
+)
+assert:register("assertion", "sint64", is_sint64, "assertion.sint64.positive", "assertion.sint64.negative")
+
+describe("bitwise function", function()
+	describe("b_and", function()
+		it("should support FFI integers", function()
+			assert.equal(0b0110, b_and(0b1110LL, 0b0111LL))
+			assert.equal(0x20, b_and(0x120, 0x71LL))
+			assert.equal(0, b_and(99LL, 0))
+			assert.equal(-4ULL, b_and(-3LL, -2LL))
+			assert(b_and(2LL ^ 53 + 1, -1LL) > 2LL ^ 53)
+		end)
+
+		it("should return FFI integers where appropriate", function()
+			assert.equal("number", type(b_and(3, 1)))
+			assert.equal("cdata", type(b_and(3LL, 1LL)))
+			assert.equal("cdata", type(b_and(3LL, 1)))
+		end)
+	end)
+
+	describe("b_or", function()
+		it("should support FFI integers", function()
+			assert.equal(0b1111, b_or(0b1110LL, 0b0111LL))
+			assert.equal(0x171, b_or(0x120, 0x71LL))
+			assert.equal(99, b_or(99LL, 0LL))
+			assert.equal(-1ULL, b_or(-3LL, -2LL))
+			assert(b_or(2LL ^ 53, 1) > 2LL ^ 53)
+		end)
+
+		it("should return FFI integers where appropriate", function()
+			assert.equal("number", type(b_or(2, 1)))
+			assert.equal("cdata", type(b_or(2LL, 1LL)))
+			assert.equal("cdata", type(b_or(2LL, 1)))
+		end)
+	end)
+
+	describe("b_xor", function()
+		it("should support FFI integers", function()
+			assert.equal(0b1001, b_xor(0b1110LL, 0b0111LL))
+			assert.equal(0x151, b_xor(0x120, 0x71LL))
+			assert.equal(99, b_xor(99LL, 0LL))
+			assert.equal(3, b_xor(-3LL, -2LL))
+			assert(b_xor(2LL ^ 53, 1) > 2LL ^ 53)
+		end)
+
+		it("should return FFI integers where appropriate", function()
+			assert.equal("number", type(b_xor(6, 3)))
+			assert.equal("cdata", type(b_xor(6LL, 3LL)))
+			assert.equal("cdata", type(b_xor(6LL, 3)))
+		end)
+	end)
+
+	describe("b_not", function()
+		it("should support FFI integers", function()
+			assert.equal(-1ULL, b_not(0LL))
+			assert.equal(-10ULL, b_not(10) + 1)
+			assert.equal(10, b_not(-10LL - 1))
+		end)
+
+		it("should return FFI integers where appropriate", function()
+			assert.equal("number", type(b_not(-1)))
+			assert.equal("cdata", type(b_not(0)))
+			assert.equal("cdata", type(b_not(0LL)))
+			assert.equal("cdata", type(b_not(-1LL)))
+			assert.equal("cdata", type(b_not(-1ULL)))
+		end)
+	end)
+
+	describe("b_lshift", function()
+		it("should support FFI integers", function()
+			assert.equal(2 ^ 2, b_lshift(1LL, 2LL))
+			assert.equal(40, b_lshift(10LL, 2))
+			assert.equal(0x8000000000000000LL, b_lshift(1, 63))
+			assert.equal(1, b_lshift(1, 64)) -- only lowest 6 bits used
+			assert(b_lshift(1LL, 53) + 1 > b_lshift(1LL, 53))
+			assert(b_lshift(1LL, 63) + 1 > b_lshift(1LL, 63))
+		end)
+
+		it("should return FFI integers where appropriate", function()
+			assert.equal("number", type(b_lshift(1, 0)))
+			assert.equal("number", type(b_lshift(1, 52)))
+			assert.equal("cdata", type(b_lshift(1, 53)))
+			assert.equal("cdata", type(b_lshift(1LL, 0)))
+			assert.equal("cdata", type(b_lshift(1, 0LL)))
+		end)
+	end)
+
+	describe("b_rshift", function()
+		it("should support FFI integers", function()
+			assert.equal(16, b_rshift(64LL, 2LL))
+			assert.equal(2, b_rshift(10LL, 2))
+			assert.equal(1, b_rshift(1, 0))
+			assert.equal(1, b_rshift(1, 64)) -- only lowest 6 bits used
+			assert.equal(1, b_rshift(-1LL, 63))
+			assert(b_lshift(1LL, 53) + 1 > b_lshift(1LL, 53))
+			assert(b_lshift(1LL, 63) + 1 > b_lshift(1LL, 63))
+		end)
+
+		it("should return FFI integers where appropriate", function()
+			assert.equal("number", type(b_rshift(1, 0)))
+			assert.equal("number", type(b_rshift(2 ^ 53 - 1, 0)))
+			assert.equal("cdata", type(b_rshift(2LL ^ 53 - 1, 0)))
+			assert.equal("cdata", type(b_rshift(1LL, 0)))
+			assert.equal("cdata", type(b_rshift(1, 0LL)))
+		end)
+	end)
+end)
+
+describe("lasr function", function()
+	it("getBaseAddress should return uint64", function()
+		assert.uint64(getBaseAddress())
+		assert.uint64(getBaseAddress("libc"))
+	end)
+
+	it("getModuleSize should return uint64", function()
+		assert.uint64(getModuleSize())
+		assert.uint64(getModuleSize("libc"))
+	end)
+
+	it("sizeOf should return uint64", function()
+		assert.identical(4ULL, sizeOf("uint"))
+		assert.identical(8ULL, sizeOf("double"))
+		assert.identical(1ULL, sizeOf("bool"))
+	end)
+
+	it("getPID should still return number", function()
+		assert.equal("number", type(getPID()))
+	end)
+
+	it("readAddress should take and return FFI integers", function()
+		local elf_magic = 0x464c457f -- '\x7fELF' in little endian
+		local elf_mask = 0xffffffff
+		assert.equal("number", type(readAddress("uint", 0LL)))
+		assert.equal(elf_magic, readAddress("uint", 0LL))
+		assert.sint64(readAddress("long", 0))
+		assert.uint64(readAddress("ulong", 0))
+		assert.equal(elf_magic, readAddress("uint", 0LL))
+		assert.equal(elf_magic, b_and(elf_mask, readAddress("long", 0ULL)))
+		assert.equal(elf_magic, b_and(elf_mask, readAddress("ulong", 0LL)))
+	end)
+
+	it("sig_scan should take and return FFI integers", function()
+		assert.identical(-1LL, sig_scan("7f 45 4c 46", -1LL))
+	end)
+
+	it("getMaps should use uint64 for size/offset fields", function()
+		for _, map in ipairs(getMaps()) do
+			assert.uint64(map.start)
+			assert.uint64(map["end"]) -- oh that's annoying
+			assert.uint64(map.size)
+		end
+	end)
+end)
+
+it("functions should error when floating-point input is too large to be accurate", function()
+	local bad = 2 ^ 53
+	assert.equal(bad, bad + 1)
+	assert.Not.equal(bad, bad - 1)
+
+	io.write("\x1b[s") -- save cursor position
+	assert(b_and(bad, 0) == nil)
+	assert(b_or(bad, 0LL) == nil)
+	assert(b_xor(bad, 0LL) == nil)
+	assert(b_not(bad) == nil)
+	assert(b_lshift(bad, 0) == nil)
+	assert(b_rshift(bad, 0) == nil)
+	assert.equal(nil, readAddress("uint", bad))
+	assert.equal(nil, sig_scan("7f 45 4c 46", bad))
+	io.write("\x1b[u") -- restore cursor position
+	io.write("\x1b[J") -- clear from cursor to end of screen, erasing error messages
+end)
+
+describe("FFI integers", function()
+	it("should concatenate with string", function()
+		assert.equal("x = -1LL", "x = " .. -1LL)
+		assert.equal("y = 2ULL", "y = " .. 2ULL)
+		assert.equal("42LL <- important", 42LL .. " <- important")
+		assert.equal("array[23ULL] @ offset -10LL", "array[" .. 23ULL .. "] @ offset " .. -10LL)
+	end)
+
+	it("should concatenate with numeric types", function()
+		assert.equal("-2LL3", -2LL .. 3)
+		assert.equal("1LL2LL", 1LL .. 2LL)
+		assert.equal("4ULL5ULL", 4ULL .. 5ULL)
+	end)
+
+	-- stylua: ignore
+	it("should not concatenate with other types", function()
+		assert.error.matches(function() local _ = 1LL .. {} end, '^attempt to concatenate')
+		assert.error.matches(function() local _ = 1LL .. false end, '^attempt to concatenate')
+		assert.error.matches(function() local _ = 1LL .. function() end end, '^attempt to concatenate')
+		assert.error.matches(function() local _ = 1LL .. nil end, '^attempt to concatenate')
+	end)
+end)


### PR DESCRIPTION
- Fix #308 by taking and returning 64-bit FFI integers for addresses, offsets and sizes.
- Partially resolve #312 by adding concatenation support for FFI integers, although it's unclear what else this issue means.
- Update wiki to cover the use of 64-bit integers.

The latest commit hacks together a very ugly test harness and adds some unit tests. These are just to show my work and should be reverted before merging. Maybe they can be included in a future test suite, but I don't know that [busted](https://lunarmodules.github.io/busted/) will be the right choice for such a thing. Tests can be run as follows:
```bash
$ luarocks --local --lua-version 5.1 install busted
  # OR install through OS package manager:
  $ sudo pacman -S lua51-busted
$ eval $(luarocks path --lua-version 5.1)
$ build/libresplit
  # `Open Auto Splitter` > `test.lua`
Process: libresplit
PID: 509929
●●●●●●●●●●●●●●●●●●●●●●●
23 successes / 0 failures / 0 errors / 0 pending : 0.07937 seconds
```

Also, it would be nice to be able to pass these values to `math.abs`, `math.max`, `math.min` and maybe some other standard library functions; arguably this is part of #312. I decided to save this for a later discussion as it raises some thorny performance and implementation questions.